### PR TITLE
feat: Iteration 2b — Tab 3 Delivery Health + drill navigation

### DIFF
--- a/backend/app/api/v1/delivery.py
+++ b/backend/app/api/v1/delivery.py
@@ -1,0 +1,102 @@
+"""Delivery-Health read endpoints — sprints, EVM, flow, phases, milestones.
+
+All are GET-only and filter by program_id or project_id. Each router is
+its own APIRouter so the /api/v1/router.py can mount them with distinct
+prefixes (/sprints, /evm, /flow, /phases, /milestones).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.models import (
+    EvmSnapshot,
+    FlowMetrics,
+    Milestone,
+    ProjectPhase,
+    SprintData,
+)
+from app.schemas.delivery import (
+    EvmSnapshotOut,
+    FlowMetricsOut,
+    MilestoneOut,
+    ProjectPhaseOut,
+    SprintOut,
+)
+
+sprints_router = APIRouter(prefix="/sprints", tags=["delivery"])
+evm_router = APIRouter(prefix="/evm", tags=["delivery"])
+flow_router = APIRouter(prefix="/flow", tags=["delivery"])
+phases_router = APIRouter(prefix="/phases", tags=["delivery"])
+milestones_router = APIRouter(prefix="/milestones", tags=["delivery"])
+
+
+@sprints_router.get("", response_model=list[SprintOut])
+async def list_sprints(
+    program_id: int | None = Query(default=None),
+    project_id: int | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[SprintData]:
+    stmt = select(SprintData)
+    if program_id is not None:
+        stmt = stmt.where(SprintData.program_id == program_id)
+    if project_id is not None:
+        stmt = stmt.where(SprintData.project_id == project_id)
+    stmt = stmt.order_by(SprintData.sprint_number.asc().nulls_last())
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@evm_router.get("", response_model=list[EvmSnapshotOut])
+async def list_evm(
+    program_id: int | None = Query(default=None),
+    project_id: int | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[EvmSnapshot]:
+    stmt = select(EvmSnapshot)
+    if program_id is not None:
+        stmt = stmt.where(EvmSnapshot.program_id == program_id)
+    if project_id is not None:
+        stmt = stmt.where(EvmSnapshot.project_id == project_id)
+    stmt = stmt.order_by(EvmSnapshot.snapshot_date.asc())
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@flow_router.get("", response_model=list[FlowMetricsOut])
+async def list_flow(
+    project_id: int | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[FlowMetrics]:
+    stmt = select(FlowMetrics)
+    if project_id is not None:
+        stmt = stmt.where(FlowMetrics.project_id == project_id)
+    stmt = stmt.order_by(FlowMetrics.period_start.asc())
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@phases_router.get("", response_model=list[ProjectPhaseOut])
+async def list_phases(
+    project_id: int | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[ProjectPhase]:
+    stmt = select(ProjectPhase)
+    if project_id is not None:
+        stmt = stmt.where(ProjectPhase.project_id == project_id)
+    stmt = stmt.order_by(ProjectPhase.phase_sequence.asc())
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@milestones_router.get("", response_model=list[MilestoneOut])
+async def list_milestones(
+    program_id: int | None = Query(default=None),
+    project_id: int | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[Milestone]:
+    stmt = select(Milestone)
+    if program_id is not None:
+        stmt = stmt.where(Milestone.program_id == program_id)
+    if project_id is not None:
+        stmt = stmt.where(Milestone.project_id == project_id)
+    stmt = stmt.order_by(Milestone.planned_date.asc())
+    return list((await session.execute(stmt)).scalars().all())

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,6 +6,7 @@ from app.api.v1 import (
     currency,
     customer,
     data_import,
+    delivery,
     health,
     kpi,
     programmes,
@@ -20,5 +21,10 @@ api_router.include_router(kpi.router)
 api_router.include_router(risks.router)
 api_router.include_router(customer.router)
 api_router.include_router(currency.router)
+api_router.include_router(delivery.sprints_router)
+api_router.include_router(delivery.evm_router)
+api_router.include_router(delivery.flow_router)
+api_router.include_router(delivery.phases_router)
+api_router.include_router(delivery.milestones_router)
 api_router.include_router(settings.router)
 api_router.include_router(data_import.router)

--- a/backend/app/schemas/delivery.py
+++ b/backend/app/schemas/delivery.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SprintOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    program_id: int | None = None
+    project_id: int | None = None
+    sprint_number: int | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    planned_points: int | None = None
+    completed_points: int | None = None
+    velocity: float | None = None
+    defects_found: int | None = None
+    defects_fixed: int | None = None
+    rework_hours: float | None = None
+    team_size: int | None = None
+    ai_assisted_points: int
+    iteration_type: str
+    estimation_unit: str
+
+
+class EvmSnapshotOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    program_id: int | None = None
+    project_id: int | None = None
+    snapshot_date: date
+    planned_value: float
+    earned_value: float
+    actual_cost: float
+    percent_complete: float | None = None
+    bac: float | None = None
+    cpi: float | None = None
+    spi: float | None = None
+    eac: float | None = None
+    tcpi: float | None = None
+    vac: float | None = None
+    notes: str | None = None
+
+
+class FlowMetricsOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    project_id: int | None = None
+    period_start: date | None = None
+    period_end: date | None = None
+    throughput_items: int | None = None
+    wip_avg: float | None = None
+    wip_limit: int | None = None
+    cycle_time_p50: float | None = None
+    cycle_time_p85: float | None = None
+    cycle_time_p95: float | None = None
+    lead_time_avg: float | None = None
+    blocked_time_hours: float | None = None
+    created_at: datetime
+
+
+class ProjectPhaseOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    project_id: int | None = None
+    phase_name: str
+    phase_sequence: int | None = None
+    planned_start: date | None = None
+    planned_end: date | None = None
+    actual_start: date | None = None
+    actual_end: date | None = None
+    percent_complete: float | None = None
+    gate_status: str | None = None
+    gate_approver: str | None = None
+    gate_date: date | None = None
+    notes: str | None = None
+
+
+class MilestoneOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    program_id: int | None = None
+    project_id: int | None = None
+    name: str
+    planned_date: date
+    actual_date: date | None = None
+    status: str
+    dependencies: str | None = None
+    owner: str | None = None
+    notes: str | None = None

--- a/backend/app/seed/delivery_data.py
+++ b/backend/app/seed/delivery_data.py
@@ -1,0 +1,656 @@
+"""Delivery-Health demo data — sprints, flow, phases, EVM, milestones.
+
+Lives alongside app/seed/data.py but is grouped here because the volume
+is large and it is only consumed by Tab 3 (Delivery Health) in Iteration
+2b. Figures are shaped to match the narrative in docs/DEMO_GUIDE.md:
+Phoenix compressing, Sentinel lifting on AI augmentation, Orion ingest
+pipeline degrading due to bench tax, Titan Waterfall mid-flight.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import TypedDict
+
+# ---------------------------------------------------------------------------
+# Internal date helpers — defined up-front so module-level builders can use them.
+# ---------------------------------------------------------------------------
+
+
+def _weeks(n: int) -> timedelta:
+    return timedelta(weeks=n)
+
+
+def _months_after(start: date, count: int) -> list[date]:
+    """Return `count` month-start dates beginning at `start`."""
+    out: list[date] = []
+    year, month = start.year, start.month
+    for _ in range(count):
+        out.append(date(year, month, 1))
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Sprints (Scrum projects only)
+# ---------------------------------------------------------------------------
+
+
+class SprintSeed(TypedDict):
+    project_code: str
+    sprint_number: int
+    start_date: date
+    end_date: date
+    planned_points: int
+    completed_points: int
+    velocity: float
+    defects_found: int
+    defects_fixed: int
+    rework_hours: float
+    team_size: int
+    ai_assisted_points: int
+    iteration_type: str
+    estimation_unit: str
+
+
+# Each Scrum project: 6 recent sprints, 14-day cadence ending around 2026-04-06.
+# PHOE-CBM: no AI, velocity compressing as rework climbs.
+# PHOE-INT: light AI, steady.
+# SNTL-AUTO: heavy AI, velocity uplift visible.
+SPRINTS: list[SprintSeed] = [
+    # PHOE-CBM — Core Banking Module (declining)
+    *(
+        {
+            "project_code": "PHOE-CBM",
+            "sprint_number": 19 + i,
+            "start_date": date(2026, 1, 12) + _weeks(i * 2),
+            "end_date": date(2026, 1, 25) + _weeks(i * 2),
+            "planned_points": 90,
+            "completed_points": [85, 82, 78, 74, 70, 68][i],
+            "velocity": [85, 82, 78, 74, 70, 68][i],
+            "defects_found": [8, 10, 12, 14, 15, 17][i],
+            "defects_fixed": [7, 8, 9, 10, 11, 12][i],
+            "rework_hours": [18.0, 22.0, 26.0, 32.0, 38.0, 45.0][i],
+            "team_size": 8,
+            "ai_assisted_points": 0,
+            "iteration_type": "Sprint",
+            "estimation_unit": "StoryPoints",
+        }
+        for i in range(6)
+    ),
+    # PHOE-INT — Integration Layer (steady with light AI)
+    *(
+        {
+            "project_code": "PHOE-INT",
+            "sprint_number": 14 + i,
+            "start_date": date(2026, 1, 12) + _weeks(i * 2),
+            "end_date": date(2026, 1, 25) + _weeks(i * 2),
+            "planned_points": 100,
+            "completed_points": [95, 97, 94, 98, 96, 99][i],
+            "velocity": [95, 97, 94, 98, 96, 99][i],
+            "defects_found": [5, 4, 6, 4, 5, 4][i],
+            "defects_fixed": [5, 4, 6, 4, 5, 4][i],
+            "rework_hours": [12.0, 10.0, 11.0, 9.0, 10.0, 8.0][i],
+            "team_size": 9,
+            "ai_assisted_points": [18, 22, 25, 28, 30, 32][i],
+            "iteration_type": "Sprint",
+            "estimation_unit": "StoryPoints",
+        }
+        for i in range(6)
+    ),
+    # SNTL-AUTO — Automation Platform (heavy AI, accelerating)
+    *(
+        {
+            "project_code": "SNTL-AUTO",
+            "sprint_number": 12 + i,
+            "start_date": date(2026, 1, 12) + _weeks(i * 2),
+            "end_date": date(2026, 1, 25) + _weeks(i * 2),
+            "planned_points": 70,
+            "completed_points": [74, 78, 82, 85, 88, 92][i],
+            "velocity": [74, 78, 82, 85, 88, 92][i],
+            "defects_found": [2, 2, 1, 2, 1, 1][i],
+            "defects_fixed": [2, 2, 1, 2, 1, 1][i],
+            "rework_hours": [6.0, 5.5, 5.0, 4.5, 4.0, 3.5][i],
+            "team_size": 7,
+            "ai_assisted_points": [35, 40, 44, 48, 52, 56][i],
+            "iteration_type": "Sprint",
+            "estimation_unit": "StoryPoints",
+        }
+        for i in range(6)
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Flow metrics (Kanban projects — weekly rows, 12 weeks)
+# ---------------------------------------------------------------------------
+
+
+class FlowMetricsSeed(TypedDict):
+    project_code: str
+    period_start: date
+    period_end: date
+    throughput_items: int
+    wip_avg: float
+    wip_limit: int
+    cycle_time_p50: float
+    cycle_time_p85: float
+    cycle_time_p95: float
+    lead_time_avg: float
+    blocked_time_hours: float
+
+
+FLOW_METRICS: list[FlowMetricsSeed] = [
+    # ATLS-LNS — steady Kanban workstream
+    *(
+        {
+            "project_code": "ATLS-LNS",
+            "period_start": date(2026, 1, 12) + _weeks(i),
+            "period_end": date(2026, 1, 18) + _weeks(i),
+            "throughput_items": [8, 9, 7, 10, 9, 8, 11, 10, 9, 11, 12, 10][i],
+            "wip_avg": [12.0, 13.5, 13.0, 12.5, 12.0, 13.0, 11.5, 12.0, 12.5, 11.0, 11.5, 12.0][i],
+            "wip_limit": 15,
+            "cycle_time_p50": [3.0, 3.2, 3.5, 3.1, 3.0, 3.2, 2.8, 3.0, 3.1, 2.8, 2.7, 2.9][i],
+            "cycle_time_p85": [6.0, 6.4, 7.0, 6.2, 5.8, 6.3, 5.5, 5.9, 6.0, 5.5, 5.3, 5.7][i],
+            "cycle_time_p95": [9.0, 9.5, 10.2, 9.0, 8.5, 9.2, 8.0, 8.6, 8.8, 8.0, 7.8, 8.3][i],
+            "lead_time_avg": [8.5, 9.0, 9.5, 8.8, 8.3, 9.0, 7.9, 8.4, 8.6, 7.9, 7.6, 8.1][i],
+            "blocked_time_hours": [2.5, 3.0, 3.5, 2.5, 2.0, 3.0, 1.8, 2.2, 2.4, 2.0, 1.8, 2.1][i],
+        }
+        for i in range(12)
+    ),
+    # ORN-INGEST — degrading Kanban throughput (bench tax)
+    *(
+        {
+            "project_code": "ORN-INGEST",
+            "period_start": date(2026, 1, 12) + _weeks(i),
+            "period_end": date(2026, 1, 18) + _weeks(i),
+            "throughput_items": [10, 10, 9, 8, 8, 7, 7, 6, 6, 5, 5, 4][i],
+            "wip_avg": [14.0, 14.5, 15.0, 15.5, 16.0, 16.5, 17.0, 17.5, 18.0, 18.5, 19.0, 19.5][i],
+            "wip_limit": 18,
+            "cycle_time_p50": [3.5, 3.8, 4.0, 4.4, 4.8, 5.2, 5.7, 6.1, 6.6, 7.0, 7.4, 7.9][i],
+            "cycle_time_p85": [7.0, 7.6, 8.2, 9.0, 9.8, 10.7, 11.5, 12.4, 13.3, 14.1, 15.0, 15.9][i],
+            "cycle_time_p95": [10.5, 11.4, 12.3, 13.5, 14.7, 16.0, 17.3, 18.6, 19.9, 21.2, 22.5, 23.9][i],
+            "lead_time_avg": [9.5, 10.3, 11.1, 12.2, 13.3, 14.5, 15.6, 16.8, 18.0, 19.1, 20.3, 21.5][i],
+            "blocked_time_hours": [4.0, 4.5, 5.2, 6.0, 6.8, 7.8, 8.7, 9.7, 10.8, 11.8, 12.9, 14.0][i],
+        }
+        for i in range(12)
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Project phases (Waterfall project)
+# ---------------------------------------------------------------------------
+
+
+class ProjectPhaseSeed(TypedDict):
+    project_code: str
+    phase_name: str
+    phase_sequence: int
+    planned_start: date
+    planned_end: date
+    actual_start: date | None
+    actual_end: date | None
+    percent_complete: float
+    gate_status: str
+    gate_approver: str | None
+    gate_date: date | None
+    notes: str | None
+
+
+PROJECT_PHASES: list[ProjectPhaseSeed] = [
+    {
+        "project_code": "TTN-STORE",
+        "phase_name": "Requirements",
+        "phase_sequence": 1,
+        "planned_start": date(2025, 9, 15),
+        "planned_end": date(2025, 11, 15),
+        "actual_start": date(2025, 9, 15),
+        "actual_end": date(2025, 11, 20),
+        "percent_complete": 100.0,
+        "gate_status": "passed",
+        "gate_approver": "J. Wilson",
+        "gate_date": date(2025, 11, 22),
+        "notes": "5-day slip; acceptable within tolerance",
+    },
+    {
+        "project_code": "TTN-STORE",
+        "phase_name": "Design",
+        "phase_sequence": 2,
+        "planned_start": date(2025, 11, 16),
+        "planned_end": date(2026, 1, 15),
+        "actual_start": date(2025, 11, 21),
+        "actual_end": date(2026, 1, 25),
+        "percent_complete": 100.0,
+        "gate_status": "passed",
+        "gate_approver": "J. Wilson",
+        "gate_date": date(2026, 1, 27),
+        "notes": "10-day slip; scope reduced on non-critical integrations",
+    },
+    {
+        "project_code": "TTN-STORE",
+        "phase_name": "Development",
+        "phase_sequence": 3,
+        "planned_start": date(2026, 1, 16),
+        "planned_end": date(2026, 4, 30),
+        "actual_start": date(2026, 1, 26),
+        "actual_end": None,
+        "percent_complete": 62.0,
+        "gate_status": "pending",
+        "gate_approver": None,
+        "gate_date": None,
+        "notes": "On track despite earlier slips; AI augmentation accelerating",
+    },
+    {
+        "project_code": "TTN-STORE",
+        "phase_name": "Test",
+        "phase_sequence": 4,
+        "planned_start": date(2026, 5, 1),
+        "planned_end": date(2026, 6, 30),
+        "actual_start": None,
+        "actual_end": None,
+        "percent_complete": 0.0,
+        "gate_status": "pending",
+        "gate_approver": None,
+        "gate_date": None,
+        "notes": None,
+    },
+    {
+        "project_code": "TTN-STORE",
+        "phase_name": "UAT",
+        "phase_sequence": 5,
+        "planned_start": date(2026, 7, 1),
+        "planned_end": date(2026, 8, 15),
+        "actual_start": None,
+        "actual_end": None,
+        "percent_complete": 0.0,
+        "gate_status": "pending",
+        "gate_approver": None,
+        "gate_date": None,
+        "notes": None,
+    },
+    {
+        "project_code": "TTN-STORE",
+        "phase_name": "Deploy",
+        "phase_sequence": 6,
+        "planned_start": date(2026, 8, 16),
+        "planned_end": date(2026, 9, 30),
+        "actual_start": None,
+        "actual_end": None,
+        "percent_complete": 0.0,
+        "gate_status": "pending",
+        "gate_approver": None,
+        "gate_date": None,
+        "notes": None,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# EVM snapshots (all projects, monthly — 12 months)
+# ---------------------------------------------------------------------------
+
+
+class EvmSnapshotSeed(TypedDict):
+    project_code: str
+    snapshot_date: date
+    planned_value: float
+    earned_value: float
+    actual_cost: float
+    percent_complete: float
+    bac: float
+    notes: str | None
+
+
+def _evm_series(
+    project_code: str,
+    bac: float,
+    start: date,
+    *,
+    pv_curve: list[float],
+    cpi_trend: list[float],
+    spi_trend: list[float],
+    notes_final: str,
+) -> list[EvmSnapshotSeed]:
+    out: list[EvmSnapshotSeed] = []
+    for i, month_start in enumerate(_months_after(start, 12)):
+        pv = bac * pv_curve[i]
+        cpi = cpi_trend[i]
+        spi = spi_trend[i]
+        ev = pv * spi
+        ac = ev / cpi if cpi > 0 else ev
+        percent_complete = (ev / bac) * 100 if bac > 0 else 0.0
+        out.append(
+            {
+                "project_code": project_code,
+                "snapshot_date": month_start,
+                "planned_value": round(pv, 2),
+                "earned_value": round(ev, 2),
+                "actual_cost": round(ac, 2),
+                "percent_complete": round(percent_complete, 2),
+                "bac": bac,
+                "notes": notes_final if i == len(pv_curve) - 1 else None,
+            }
+        )
+    return out
+
+
+EVM_SNAPSHOTS: list[EvmSnapshotSeed] = [
+    *_evm_series(
+        "PHOE-CBM",
+        4_200_000,
+        date(2025, 5, 1),
+        pv_curve=[0.05, 0.12, 0.20, 0.28, 0.36, 0.44, 0.52, 0.60, 0.68, 0.76, 0.84, 0.92],
+        cpi_trend=[1.02, 1.00, 0.98, 0.96, 0.94, 0.92, 0.90, 0.89, 0.88, 0.87, 0.87, 0.87],
+        spi_trend=[1.00, 0.98, 0.97, 0.95, 0.93, 0.92, 0.90, 0.88, 0.86, 0.85, 0.85, 0.84],
+        notes_final="Rework cost escalating; recovery plan in CAB",
+    ),
+    *_evm_series(
+        "PHOE-INT",
+        3_200_000,
+        date(2025, 5, 1),
+        pv_curve=[0.04, 0.10, 0.17, 0.24, 0.31, 0.39, 0.47, 0.55, 0.63, 0.71, 0.79, 0.87],
+        cpi_trend=[1.02, 1.01, 1.00, 0.99, 0.98, 0.97, 0.97, 0.96, 0.95, 0.95, 0.94, 0.93],
+        spi_trend=[1.01, 1.00, 0.99, 0.99, 0.98, 0.97, 0.96, 0.95, 0.94, 0.93, 0.92, 0.91],
+        notes_final="Within amber band; watch trend",
+    ),
+    *_evm_series(
+        "ATLS-LNS",
+        3_500_000,
+        date(2025, 7, 1),
+        pv_curve=[0.04, 0.10, 0.18, 0.26, 0.34, 0.42, 0.50, 0.58, 0.66, 0.74, 0.82, 0.90],
+        cpi_trend=[1.05, 1.04, 1.02, 1.00, 0.98, 0.97, 0.96, 0.95, 0.94, 0.93, 0.92, 0.91],
+        spi_trend=[1.00, 1.00, 0.99, 0.98, 0.97, 0.96, 0.95, 0.95, 0.94, 0.93, 0.92, 0.91],
+        notes_final="Margin cliff scenario active; team mix under review",
+    ),
+    *_evm_series(
+        "SNTL-AUTO",
+        2_800_000,
+        date(2025, 8, 1),
+        pv_curve=[0.05, 0.13, 0.22, 0.31, 0.40, 0.49, 0.58, 0.67, 0.76, 0.83, 0.90, 0.96],
+        cpi_trend=[1.08, 1.09, 1.10, 1.11, 1.12, 1.12, 1.13, 1.14, 1.14, 1.15, 1.15, 1.16],
+        spi_trend=[1.01, 1.02, 1.02, 1.03, 1.04, 1.05, 1.05, 1.06, 1.06, 1.07, 1.07, 1.07],
+        notes_final="Best-in-class performance; AI augmentation paying off",
+    ),
+    *_evm_series(
+        "ORN-INGEST",
+        5_500_000,
+        date(2025, 3, 1),
+        pv_curve=[0.03, 0.09, 0.16, 0.23, 0.30, 0.38, 0.46, 0.54, 0.62, 0.70, 0.78, 0.86],
+        cpi_trend=[0.98, 0.96, 0.94, 0.92, 0.90, 0.88, 0.86, 0.85, 0.84, 0.83, 0.82, 0.81],
+        spi_trend=[1.00, 0.99, 0.97, 0.95, 0.93, 0.91, 0.89, 0.88, 0.86, 0.85, 0.84, 0.83],
+        notes_final="Red corridor; bench rationalisation in flight",
+    ),
+    *_evm_series(
+        "TTN-STORE",
+        3_200_000,
+        date(2025, 10, 1),
+        pv_curve=[0.03, 0.10, 0.18, 0.26, 0.34, 0.42, 0.50, 0.58, 0.66, 0.74, 0.82, 0.90],
+        cpi_trend=[1.04, 1.02, 1.00, 0.98, 0.97, 0.95, 0.94, 0.92, 0.91, 0.90, 0.89, 0.88],
+        spi_trend=[1.00, 0.99, 0.98, 0.96, 0.95, 0.93, 0.92, 0.91, 0.90, 0.88, 0.87, 0.86],
+        notes_final="Gate slip absorbed; dev phase 62% complete",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Milestones (every project gets 4–6)
+# ---------------------------------------------------------------------------
+
+
+class MilestoneSeed(TypedDict):
+    project_code: str
+    name: str
+    planned_date: date
+    actual_date: date | None
+    status: str
+    owner: str | None
+    notes: str | None
+
+
+MILESTONES: list[MilestoneSeed] = [
+    # PHOE-CBM
+    {
+        "project_code": "PHOE-CBM",
+        "name": "Sprint 0 complete",
+        "planned_date": date(2025, 5, 15),
+        "actual_date": date(2025, 5, 15),
+        "status": "Completed",
+        "owner": "Priya Sharma",
+        "notes": "On time",
+    },
+    {
+        "project_code": "PHOE-CBM",
+        "name": "Core module feature-complete",
+        "planned_date": date(2025, 12, 31),
+        "actual_date": date(2026, 1, 18),
+        "status": "Completed",
+        "owner": "Priya Sharma",
+        "notes": "18-day slip; scope 93% delivered",
+    },
+    {
+        "project_code": "PHOE-CBM",
+        "name": "Integration ready",
+        "planned_date": date(2026, 3, 31),
+        "actual_date": None,
+        "status": "Delayed",
+        "owner": "Priya Sharma",
+        "notes": "Vendor dependency; 3-week slip projected",
+    },
+    {
+        "project_code": "PHOE-CBM",
+        "name": "UAT sign-off",
+        "planned_date": date(2026, 6, 30),
+        "actual_date": None,
+        "status": "At Risk",
+        "owner": "Priya Sharma",
+        "notes": "Contingent on integration recovery",
+    },
+    {
+        "project_code": "PHOE-CBM",
+        "name": "Go-live",
+        "planned_date": date(2026, 9, 30),
+        "actual_date": None,
+        "status": "At Risk",
+        "owner": "Priya Sharma",
+        "notes": "Buffer consumed; re-baseline in progress",
+    },
+    # PHOE-INT
+    {
+        "project_code": "PHOE-INT",
+        "name": "Contract signed",
+        "planned_date": date(2025, 5, 1),
+        "actual_date": date(2025, 5, 1),
+        "status": "Completed",
+        "owner": "Raj Kumar",
+        "notes": None,
+    },
+    {
+        "project_code": "PHOE-INT",
+        "name": "API adapter live",
+        "planned_date": date(2026, 1, 31),
+        "actual_date": date(2026, 2, 10),
+        "status": "Completed",
+        "owner": "Raj Kumar",
+        "notes": "10-day slip",
+    },
+    {
+        "project_code": "PHOE-INT",
+        "name": "Event bus integrated",
+        "planned_date": date(2026, 5, 31),
+        "actual_date": None,
+        "status": "In Progress",
+        "owner": "Raj Kumar",
+        "notes": None,
+    },
+    {
+        "project_code": "PHOE-INT",
+        "name": "Production cutover",
+        "planned_date": date(2026, 12, 15),
+        "actual_date": None,
+        "status": "Pending",
+        "owner": "Raj Kumar",
+        "notes": None,
+    },
+    # ATLS-LNS
+    {
+        "project_code": "ATLS-LNS",
+        "name": "Cloud landing zone",
+        "planned_date": date(2025, 8, 15),
+        "actual_date": date(2025, 8, 20),
+        "status": "Completed",
+        "owner": "Suresh Menon",
+        "notes": None,
+    },
+    {
+        "project_code": "ATLS-LNS",
+        "name": "Wave 1 workloads migrated",
+        "planned_date": date(2026, 2, 28),
+        "actual_date": date(2026, 3, 8),
+        "status": "Completed",
+        "owner": "Suresh Menon",
+        "notes": "8-day slip",
+    },
+    {
+        "project_code": "ATLS-LNS",
+        "name": "Wave 2 migration",
+        "planned_date": date(2026, 6, 30),
+        "actual_date": None,
+        "status": "In Progress",
+        "owner": "Suresh Menon",
+        "notes": None,
+    },
+    {
+        "project_code": "ATLS-LNS",
+        "name": "Decommission data centre",
+        "planned_date": date(2026, 12, 15),
+        "actual_date": None,
+        "status": "Pending",
+        "owner": "Suresh Menon",
+        "notes": None,
+    },
+    # SNTL-AUTO
+    {
+        "project_code": "SNTL-AUTO",
+        "name": "Pilot pipeline green",
+        "planned_date": date(2025, 10, 31),
+        "actual_date": date(2025, 10, 25),
+        "status": "Completed",
+        "owner": "Suresh Menon",
+        "notes": "Ahead of plan",
+    },
+    {
+        "project_code": "SNTL-AUTO",
+        "name": "Coverage 80% achieved",
+        "planned_date": date(2026, 2, 28),
+        "actual_date": date(2026, 2, 22),
+        "status": "Completed",
+        "owner": "Suresh Menon",
+        "notes": "Ahead of plan",
+    },
+    {
+        "project_code": "SNTL-AUTO",
+        "name": "AI trust audit",
+        "planned_date": date(2026, 5, 15),
+        "actual_date": None,
+        "status": "In Progress",
+        "owner": "Suresh Menon",
+        "notes": None,
+    },
+    {
+        "project_code": "SNTL-AUTO",
+        "name": "Final handover",
+        "planned_date": date(2026, 6, 30),
+        "actual_date": None,
+        "status": "Pending",
+        "owner": "Suresh Menon",
+        "notes": None,
+    },
+    # ORN-INGEST
+    {
+        "project_code": "ORN-INGEST",
+        "name": "Raw ingest layer",
+        "planned_date": date(2025, 6, 30),
+        "actual_date": date(2025, 7, 12),
+        "status": "Completed",
+        "owner": "Meera Iyer",
+        "notes": "12-day slip",
+    },
+    {
+        "project_code": "ORN-INGEST",
+        "name": "Curated layer live",
+        "planned_date": date(2026, 1, 31),
+        "actual_date": date(2026, 2, 28),
+        "status": "Completed",
+        "owner": "Meera Iyer",
+        "notes": "28-day slip",
+    },
+    {
+        "project_code": "ORN-INGEST",
+        "name": "Analytics marts",
+        "planned_date": date(2026, 5, 31),
+        "actual_date": None,
+        "status": "Delayed",
+        "owner": "Meera Iyer",
+        "notes": "Bench tax; redeploy plan in CAB",
+    },
+    {
+        "project_code": "ORN-INGEST",
+        "name": "Data platform GA",
+        "planned_date": date(2026, 10, 31),
+        "actual_date": None,
+        "status": "At Risk",
+        "owner": "Meera Iyer",
+        "notes": None,
+    },
+    # TTN-STORE (Waterfall)
+    {
+        "project_code": "TTN-STORE",
+        "name": "Requirements sign-off",
+        "planned_date": date(2025, 11, 15),
+        "actual_date": date(2025, 11, 20),
+        "status": "Completed",
+        "owner": "Nisha Rao",
+        "notes": "Gate passed after 5-day slip",
+    },
+    {
+        "project_code": "TTN-STORE",
+        "name": "Design sign-off",
+        "planned_date": date(2026, 1, 15),
+        "actual_date": date(2026, 1, 27),
+        "status": "Completed",
+        "owner": "Nisha Rao",
+        "notes": "Scope reduced on non-critical integrations",
+    },
+    {
+        "project_code": "TTN-STORE",
+        "name": "Development complete",
+        "planned_date": date(2026, 4, 30),
+        "actual_date": None,
+        "status": "In Progress",
+        "owner": "Nisha Rao",
+        "notes": "62% complete; on track despite earlier slips",
+    },
+    {
+        "project_code": "TTN-STORE",
+        "name": "UAT exit",
+        "planned_date": date(2026, 8, 15),
+        "actual_date": None,
+        "status": "Pending",
+        "owner": "Nisha Rao",
+        "notes": None,
+    },
+    {
+        "project_code": "TTN-STORE",
+        "name": "Go-live",
+        "planned_date": date(2026, 9, 30),
+        "actual_date": None,
+        "status": "At Risk",
+        "owner": "Nisha Rao",
+        "notes": "P1 SLA risk window",
+    },
+]
+
+

--- a/backend/app/seed/seeder.py
+++ b/backend/app/seed/seeder.py
@@ -11,11 +11,16 @@ from app.models import (
     CurrencyRate,
     CustomerAction,
     CustomerExpectation,
+    EvmSnapshot,
+    FlowMetrics,
     KpiDefinition,
     KpiSnapshot,
+    Milestone,
     Program,
     Project,
+    ProjectPhase,
     Risk,
+    SprintData,
 )
 from app.seed.data import (
     APP_SETTINGS_DEFAULTS,
@@ -28,6 +33,13 @@ from app.seed.data import (
     PROGRAMMES,
     PROJECTS,
     RISKS,
+)
+from app.seed.delivery_data import (
+    EVM_SNAPSHOTS,
+    FLOW_METRICS,
+    MILESTONES,
+    PROJECT_PHASES,
+    SPRINTS,
 )
 
 log = get_logger(__name__)
@@ -47,21 +59,32 @@ async def seed_demo_data(session: AsyncSession, *, force: bool = False) -> bool:
     await _seed_app_settings(session)
     await _seed_currency_rates(session)
     program_ids = await _seed_programmes(session)
-    await _seed_projects(session, program_ids)
+    project_ids = await _seed_projects(session, program_ids)
     kpi_ids = await _seed_kpi_definitions(session)
     await _seed_kpi_snapshots(session, program_ids, kpi_ids)
     await _seed_risks(session, program_ids)
     await _seed_customer_expectations(session, program_ids)
     await _seed_customer_actions(session, program_ids)
+    await _seed_sprints(session, program_ids, project_ids)
+    await _seed_flow_metrics(session, project_ids)
+    await _seed_project_phases(session, project_ids)
+    await _seed_evm_snapshots(session, program_ids, project_ids)
+    await _seed_milestones(session, program_ids, project_ids)
 
     await session.commit()
     log.info(
         "seed.done",
         programmes=len(program_ids),
+        projects=len(project_ids),
         kpis=len(kpi_ids),
         risks=len(RISKS),
         expectations=len(CUSTOMER_EXPECTATIONS),
         actions=len(CUSTOMER_ACTIONS),
+        sprints=len(SPRINTS),
+        flow_rows=len(FLOW_METRICS),
+        phases=len(PROJECT_PHASES),
+        evm_rows=len(EVM_SNAPSHOTS),
+        milestones=len(MILESTONES),
     )
     return True
 
@@ -100,7 +123,8 @@ async def _seed_programmes(session: AsyncSession) -> dict[str, int]:
 async def _seed_projects(
     session: AsyncSession,
     program_ids: dict[str, int],
-) -> None:
+) -> dict[str, int]:
+    project_ids: dict[str, int] = {}
     for data in PROJECTS:
         payload = dict(data)
         program_code = payload.pop("program_code")
@@ -109,6 +133,9 @@ async def _seed_projects(
             continue
         project = Project(program_id=program_id, **payload)
         session.add(project)
+        await session.flush()
+        project_ids[project.code] = project.id
+    return project_ids
 
 
 async def _seed_kpi_definitions(session: AsyncSession) -> dict[str, int]:
@@ -191,3 +218,108 @@ async def _seed_customer_actions(
         if program_id is None:
             continue
         session.add(CustomerAction(program_id=program_id, **payload))
+
+
+def _program_for_project(
+    project_code: str,
+    project_ids: dict[str, int],
+    program_ids: dict[str, int],
+) -> tuple[int | None, int | None]:
+    """Return (program_id, project_id) for a project code; None if unknown."""
+    project_id = project_ids.get(project_code)
+    if project_id is None:
+        return None, None
+    # Reverse-map project_code → program_code via the PROJECTS source table.
+    for seed in PROJECTS:
+        if seed["code"] == project_code:
+            return program_ids.get(seed["program_code"]), project_id
+    return None, project_id
+
+
+async def _seed_sprints(
+    session: AsyncSession,
+    program_ids: dict[str, int],
+    project_ids: dict[str, int],
+) -> None:
+    for data in SPRINTS:
+        payload = dict(data)
+        project_code = payload.pop("project_code")
+        program_id, project_id = _program_for_project(
+            project_code, project_ids, program_ids
+        )
+        if project_id is None:
+            continue
+        session.add(
+            SprintData(program_id=program_id, project_id=project_id, **payload)
+        )
+
+
+async def _seed_flow_metrics(
+    session: AsyncSession,
+    project_ids: dict[str, int],
+) -> None:
+    for data in FLOW_METRICS:
+        payload = dict(data)
+        project_id = project_ids.get(payload.pop("project_code"))
+        if project_id is None:
+            continue
+        session.add(FlowMetrics(project_id=project_id, **payload))
+
+
+async def _seed_project_phases(
+    session: AsyncSession,
+    project_ids: dict[str, int],
+) -> None:
+    for data in PROJECT_PHASES:
+        payload = dict(data)
+        project_id = project_ids.get(payload.pop("project_code"))
+        if project_id is None:
+            continue
+        session.add(ProjectPhase(project_id=project_id, **payload))
+
+
+async def _seed_evm_snapshots(
+    session: AsyncSession,
+    program_ids: dict[str, int],
+    project_ids: dict[str, int],
+) -> None:
+    for data in EVM_SNAPSHOTS:
+        payload = dict(data)
+        project_code = payload.pop("project_code")
+        program_id, project_id = _program_for_project(
+            project_code, project_ids, program_ids
+        )
+        if project_id is None:
+            continue
+        pv = payload["planned_value"]
+        ev = payload["earned_value"]
+        ac = payload["actual_cost"]
+        bac = payload["bac"]
+        payload["cpi"] = round(ev / ac, 4) if ac else None
+        payload["spi"] = round(ev / pv, 4) if pv else None
+        payload["eac"] = round(bac / payload["cpi"], 2) if payload["cpi"] else None
+        payload["tcpi"] = (
+            round((bac - ev) / (bac - ac), 4) if (bac - ac) > 0 else None
+        )
+        payload["vac"] = round(bac - payload["eac"], 2) if payload["eac"] else None
+        session.add(
+            EvmSnapshot(program_id=program_id, project_id=project_id, **payload)
+        )
+
+
+async def _seed_milestones(
+    session: AsyncSession,
+    program_ids: dict[str, int],
+    project_ids: dict[str, int],
+) -> None:
+    for data in MILESTONES:
+        payload = dict(data)
+        project_code = payload.pop("project_code")
+        program_id, project_id = _program_for_project(
+            project_code, project_ids, program_ids
+        )
+        if project_id is None:
+            continue
+        session.add(
+            Milestone(program_id=program_id, project_id=project_id, **payload)
+        )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ ignore = ["PLR0913", "PLR2004"]
 
 [tool.ruff.lint.per-file-ignores]
 "app/seed/data.py" = ["E501"]
+"app/seed/delivery_data.py" = ["E501"]
 "app/seed/seeder.py" = ["PLR0913"]
 "app/api/**" = ["B008"]        # FastAPI `Depends(...)` in defaults is idiomatic
 "app/database.py" = ["PLW0603"] # module-level engine cache is deliberate

--- a/backend/tests/test_delivery.py
+++ b/backend/tests/test_delivery.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    EvmSnapshot,
+    FlowMetrics,
+    Milestone,
+    Program,
+    Project,
+    ProjectPhase,
+    SprintData,
+)
+
+
+async def _seed_minimal_project(session: AsyncSession) -> tuple[int, int]:
+    programme = Program(
+        name="Test programme",
+        code="T1",
+        start_date=date(2025, 4, 1),
+    )
+    session.add(programme)
+    await session.flush()
+    project = Project(
+        program_id=programme.id,
+        name="Test project",
+        code="T1-P1",
+        delivery_methodology="Scrum",
+    )
+    session.add(project)
+    await session.flush()
+    return programme.id, project.id
+
+
+@pytest.mark.asyncio
+async def test_sprints_filter_by_project(
+    session: AsyncSession, app_client: AsyncClient
+) -> None:
+    _, project_id = await _seed_minimal_project(session)
+    session.add_all(
+        [
+            SprintData(
+                project_id=project_id,
+                sprint_number=1,
+                planned_points=50,
+                completed_points=48,
+                velocity=48,
+            ),
+            SprintData(
+                project_id=project_id,
+                sprint_number=2,
+                planned_points=50,
+                completed_points=52,
+                velocity=52,
+            ),
+        ]
+    )
+    await session.commit()
+    resp = await app_client.get("/api/v1/sprints", params={"project_id": project_id})
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 2
+    assert [r["sprint_number"] for r in rows] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_evm_filter_by_project_sorted_ascending(
+    session: AsyncSession, app_client: AsyncClient
+) -> None:
+    _, project_id = await _seed_minimal_project(session)
+    session.add_all(
+        [
+            EvmSnapshot(
+                project_id=project_id,
+                snapshot_date=date(2026, 3, 1),
+                planned_value=200,
+                earned_value=190,
+                actual_cost=210,
+                cpi=0.905,
+                spi=0.95,
+            ),
+            EvmSnapshot(
+                project_id=project_id,
+                snapshot_date=date(2026, 1, 1),
+                planned_value=100,
+                earned_value=98,
+                actual_cost=95,
+                cpi=1.03,
+                spi=0.98,
+            ),
+        ]
+    )
+    await session.commit()
+    resp = await app_client.get("/api/v1/evm", params={"project_id": project_id})
+    assert resp.status_code == 200
+    dates = [row["snapshot_date"] for row in resp.json()]
+    assert dates == sorted(dates)
+
+
+@pytest.mark.asyncio
+async def test_flow_filter_by_project(
+    session: AsyncSession, app_client: AsyncClient
+) -> None:
+    _, project_id = await _seed_minimal_project(session)
+    session.add(
+        FlowMetrics(
+            project_id=project_id,
+            period_start=date(2026, 2, 1),
+            period_end=date(2026, 2, 7),
+            throughput_items=7,
+        )
+    )
+    await session.commit()
+    resp = await app_client.get("/api/v1/flow", params={"project_id": project_id})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_phases_sorted_by_sequence(
+    session: AsyncSession, app_client: AsyncClient
+) -> None:
+    _, project_id = await _seed_minimal_project(session)
+    session.add_all(
+        [
+            ProjectPhase(
+                project_id=project_id,
+                phase_name="Test",
+                phase_sequence=4,
+                gate_status="pending",
+            ),
+            ProjectPhase(
+                project_id=project_id,
+                phase_name="Requirements",
+                phase_sequence=1,
+                gate_status="passed",
+            ),
+        ]
+    )
+    await session.commit()
+    resp = await app_client.get("/api/v1/phases", params={"project_id": project_id})
+    assert resp.status_code == 200
+    names = [row["phase_name"] for row in resp.json()]
+    assert names == ["Requirements", "Test"]
+
+
+@pytest.mark.asyncio
+async def test_milestones_sorted_by_planned_date(
+    session: AsyncSession, app_client: AsyncClient
+) -> None:
+    program_id, project_id = await _seed_minimal_project(session)
+    session.add_all(
+        [
+            Milestone(
+                program_id=program_id,
+                project_id=project_id,
+                name="Late",
+                planned_date=date(2026, 9, 30),
+                status="Pending",
+            ),
+            Milestone(
+                program_id=program_id,
+                project_id=project_id,
+                name="Early",
+                planned_date=date(2026, 5, 1),
+                status="In Progress",
+            ),
+        ]
+    )
+    await session.commit()
+    resp = await app_client.get(
+        "/api/v1/milestones", params={"project_id": project_id}
+    )
+    assert resp.status_code == 200
+    names = [row["name"] for row in resp.json()]
+    assert names == ["Early", "Late"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,8 @@
         "@tanstack/react-query": "^5.56.2",
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "lucide-react": "^0.469.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3053,6 +3055,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
@@ -3394,7 +3420,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -5121,6 +5146,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5474,6 +5505,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5913,6 +5950,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,8 @@
     "@tanstack/react-query": "^5.56.2",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "lucide-react": "^0.469.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from "@/components/Layout";
 import { queryClient } from "@/lib/queryClient";
 import { ExecutiveOverview } from "@/pages/ExecutiveOverview";
 import { DataHub } from "@/pages/DataHub";
+import { DeliveryHealth } from "@/pages/DeliveryHealth";
 import { KpiStudio } from "@/pages/KpiStudio";
 import { NotFound } from "@/pages/NotFound";
 
@@ -14,6 +15,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <ExecutiveOverview /> },
       { path: "kpi", element: <KpiStudio /> },
+      { path: "delivery", element: <DeliveryHealth /> },
       { path: "data-hub", element: <DataHub /> },
       { path: "*", element: <NotFound /> },
     ],

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+export type BreadcrumbItem = {
+  label: string;
+  /** Absolute path. Leaf item should omit `to` (it's not a link). */
+  to?: string;
+  icon?: ReactNode;
+};
+
+export function Breadcrumb({ items, className }: { items: BreadcrumbItem[]; className?: string }) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn("flex flex-wrap items-center gap-1 text-xs text-navy/60", className)}
+    >
+      {items.map((item, idx) => {
+        const isLast = idx === items.length - 1;
+        const content = (
+          <span className="inline-flex items-center gap-1">
+            {item.icon}
+            {item.label}
+          </span>
+        );
+        return (
+          <span key={`${item.label}-${idx}`} className="inline-flex items-center gap-1">
+            {item.to && !isLast ? (
+              <Link
+                to={item.to}
+                className="rounded px-1 py-0.5 text-navy/70 transition hover:bg-ice-100 hover:text-navy"
+              >
+                {content}
+              </Link>
+            ) : (
+              <span
+                className={cn(
+                  "px-1 py-0.5",
+                  isLast ? "font-semibold text-navy" : "text-navy/70",
+                )}
+                aria-current={isLast ? "page" : undefined}
+              >
+                {content}
+              </span>
+            )}
+            {!isLast ? (
+              <ChevronRight className="size-3 text-navy/40" aria-hidden="true" />
+            ) : null}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/cn";
 const tabs = [
   { to: "/", label: "Executive", num: "01" },
   { to: "/kpi", label: "KPI Studio", num: "02" },
-  { to: "/delivery", label: "Delivery", num: "03", disabled: true },
+  { to: "/delivery", label: "Delivery", num: "03" },
   { to: "/velocity", label: "Velocity & Flow", num: "04", disabled: true },
   { to: "/margin", label: "Margin & EVM", num: "05", disabled: true },
   { to: "/customer", label: "Customer", num: "06", disabled: true },

--- a/frontend/src/components/TopRisksCard.tsx
+++ b/frontend/src/components/TopRisksCard.tsx
@@ -1,4 +1,5 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, ChevronRight } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { useTopRisks, useProgrammes } from "@/hooks/usePortfolio";
@@ -16,11 +17,15 @@ export function TopRisksCard({ limit = 5 }: { limit?: number }) {
   const { data, isLoading, error } = useTopRisks(limit);
   const programmes = useProgrammes();
   const currency = useCurrency();
+  const navigate = useNavigate();
 
   // Map program_id → native currency so we can convert impact amounts
   // correctly regardless of the selected display currency.
   const currencyByProgramme = new Map(
     (programmes.data ?? []).map((p) => [p.id, p.currency_code]),
+  );
+  const codeByProgramme = new Map(
+    (programmes.data ?? []).map((p) => [p.id, p.code]),
   );
 
   return (
@@ -46,34 +51,57 @@ export function TopRisksCard({ limit = 5 }: { limit?: number }) {
       ) : (
         <ol className="flex flex-col gap-2 text-sm">
           {data.map((risk, idx) => {
+            const programmeCode =
+              risk.program_id !== null
+                ? codeByProgramme.get(risk.program_id)
+                : null;
             const sourceCurrency =
               (risk.program_id !== null &&
                 currencyByProgramme.get(risk.program_id)) ||
               "USD";
+            const drillTo = programmeCode
+              ? `/delivery?programme=${programmeCode}`
+              : null;
             return (
-              <li
-                key={risk.id}
-                className="flex items-center justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2"
-              >
-                <div className="flex items-start gap-3">
-                  <span className="mt-0.5 font-mono text-xs text-navy/60">
-                    {idx + 1}.
-                  </span>
-                  <div>
-                    <p className="font-medium">{risk.title}</p>
-                    {risk.owner ? (
-                      <p className="text-xs text-navy/60">Owner: {risk.owner}</p>
+              <li key={risk.id}>
+                <button
+                  type="button"
+                  onClick={() => drillTo && navigate(drillTo)}
+                  disabled={!drillTo}
+                  className="group flex w-full items-center justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2 text-left transition hover:bg-ice-50 disabled:cursor-default disabled:hover:bg-white"
+                  aria-label={
+                    drillTo
+                      ? `Drill into ${programmeCode} for ${risk.title}`
+                      : risk.title
+                  }
+                >
+                  <div className="flex items-start gap-3">
+                    <span className="mt-0.5 font-mono text-xs text-navy/60">
+                      {idx + 1}.
+                    </span>
+                    <div>
+                      <p className="font-medium">{risk.title}</p>
+                      <p className="text-xs text-navy/60">
+                        {programmeCode ? `${programmeCode} · ` : ""}
+                        {risk.owner ? `Owner: ${risk.owner}` : ""}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge tone={severityTone(risk.severity)}>
+                      {risk.severity ?? "—"}
+                    </Badge>
+                    <span className="font-mono text-xs text-navy/80">
+                      {currency.format(risk.impact, sourceCurrency)}
+                    </span>
+                    {drillTo ? (
+                      <ChevronRight
+                        className="size-4 text-navy/40 transition group-hover:text-navy"
+                        aria-hidden="true"
+                      />
                     ) : null}
                   </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge tone={severityTone(risk.severity)}>
-                    {risk.severity ?? "—"}
-                  </Badge>
-                  <span className="font-mono text-xs text-navy/80">
-                    {currency.format(risk.impact, sourceCurrency)}
-                  </span>
-                </div>
+                </button>
               </li>
             );
           })}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -159,6 +159,145 @@ export async function fetchCurrencyRates(): Promise<CurrencyRate[]> {
   return data;
 }
 
+// ---------- Delivery Health ----------
+
+export type Sprint = {
+  id: number;
+  program_id: number | null;
+  project_id: number | null;
+  sprint_number: number | null;
+  start_date: string | null;
+  end_date: string | null;
+  planned_points: number | null;
+  completed_points: number | null;
+  velocity: number | null;
+  defects_found: number | null;
+  defects_fixed: number | null;
+  rework_hours: number | null;
+  team_size: number | null;
+  ai_assisted_points: number;
+  iteration_type: string;
+  estimation_unit: string;
+};
+
+export type EvmSnapshot = {
+  id: number;
+  program_id: number | null;
+  project_id: number | null;
+  snapshot_date: string;
+  planned_value: number;
+  earned_value: number;
+  actual_cost: number;
+  percent_complete: number | null;
+  bac: number | null;
+  cpi: number | null;
+  spi: number | null;
+  eac: number | null;
+  tcpi: number | null;
+  vac: number | null;
+  notes: string | null;
+};
+
+export type FlowMetric = {
+  id: number;
+  project_id: number | null;
+  period_start: string | null;
+  period_end: string | null;
+  throughput_items: number | null;
+  wip_avg: number | null;
+  wip_limit: number | null;
+  cycle_time_p50: number | null;
+  cycle_time_p85: number | null;
+  cycle_time_p95: number | null;
+  lead_time_avg: number | null;
+  blocked_time_hours: number | null;
+};
+
+export type ProjectPhase = {
+  id: number;
+  project_id: number | null;
+  phase_name: string;
+  phase_sequence: number | null;
+  planned_start: string | null;
+  planned_end: string | null;
+  actual_start: string | null;
+  actual_end: string | null;
+  percent_complete: number | null;
+  gate_status: string | null;
+  gate_approver: string | null;
+  gate_date: string | null;
+  notes: string | null;
+};
+
+export type Milestone = {
+  id: number;
+  program_id: number | null;
+  project_id: number | null;
+  name: string;
+  planned_date: string;
+  actual_date: string | null;
+  status: string;
+  owner: string | null;
+  notes: string | null;
+};
+
+export type ProjectListItem = {
+  id: number;
+  program_id: number | null;
+  name: string;
+  code: string;
+  delivery_methodology: string;
+  is_ai_augmented: boolean;
+  ai_augmentation_level: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  status: string;
+};
+
+export async function fetchProjectsForProgramme(
+  programId: number,
+): Promise<ProjectListItem[]> {
+  const { data } = await api.get<ProjectListItem[]>(
+    `/api/v1/programmes/${programId}/projects`,
+  );
+  return data;
+}
+
+export async function fetchSprints(projectId: number): Promise<Sprint[]> {
+  const { data } = await api.get<Sprint[]>("/api/v1/sprints", {
+    params: { project_id: projectId },
+  });
+  return data;
+}
+
+export async function fetchEvm(projectId: number): Promise<EvmSnapshot[]> {
+  const { data } = await api.get<EvmSnapshot[]>("/api/v1/evm", {
+    params: { project_id: projectId },
+  });
+  return data;
+}
+
+export async function fetchFlow(projectId: number): Promise<FlowMetric[]> {
+  const { data } = await api.get<FlowMetric[]>("/api/v1/flow", {
+    params: { project_id: projectId },
+  });
+  return data;
+}
+
+export async function fetchPhases(projectId: number): Promise<ProjectPhase[]> {
+  const { data } = await api.get<ProjectPhase[]>("/api/v1/phases", {
+    params: { project_id: projectId },
+  });
+  return data;
+}
+
+export async function fetchMilestones(projectId: number): Promise<Milestone[]> {
+  const { data } = await api.get<Milestone[]>("/api/v1/milestones", {
+    params: { project_id: projectId },
+  });
+  return data;
+}
+
 export async function previewCsv(file: File): Promise<{
   filename: string;
   columns: string[];

--- a/frontend/src/pages/DeliveryHealth.tsx
+++ b/frontend/src/pages/DeliveryHealth.tsx
@@ -1,0 +1,360 @@
+import { useMemo, useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { ChevronLeft, ChevronRight, Home, Layers, X } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import {
+  fetchEvm,
+  fetchProjectsForProgramme,
+  type ProjectListItem,
+} from "@/lib/api";
+import { useProgrammes } from "@/hooks/usePortfolio";
+import { formatRatio } from "@/lib/format";
+import { EvmStrip } from "@/pages/delivery/EvmStrip";
+import { ScrumView } from "@/pages/delivery/ScrumView";
+import { KanbanView } from "@/pages/delivery/KanbanView";
+import { WaterfallView } from "@/pages/delivery/WaterfallView";
+
+const METHODOLOGY_TONE: Record<string, "green" | "amber" | "red" | "neutral"> = {
+  Scrum: "neutral",
+  Kanban: "neutral",
+  Waterfall: "neutral",
+  SAFe: "neutral",
+  Hybrid: "neutral",
+};
+
+export function DeliveryHealth() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const programmeFilter = searchParams.get("programme");
+  const programmes = useProgrammes();
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+
+  const allProjectsQuery = useQuery({
+    queryKey: ["projects", "all", (programmes.data ?? []).map((p) => p.id).join(",")],
+    queryFn: async () => {
+      if (!programmes.data) return [] as ProjectListItem[];
+      const lists = await Promise.all(
+        programmes.data.map((p) => fetchProjectsForProgramme(p.id)),
+      );
+      return lists.flat();
+    },
+    enabled: (programmes.data?.length ?? 0) > 0,
+  });
+
+  const allProjects = useMemo(
+    () => allProjectsQuery.data ?? [],
+    [allProjectsQuery.data],
+  );
+
+  // If ?programme=CODE is present, narrow the visible projects to that programme.
+  const filteredProgramme = useMemo(() => {
+    if (!programmeFilter) return null;
+    return programmes.data?.find((p) => p.code === programmeFilter) ?? null;
+  }, [programmeFilter, programmes.data]);
+
+  const projects = useMemo(() => {
+    if (!filteredProgramme) return allProjects;
+    return allProjects.filter((p) => p.program_id === filteredProgramme.id);
+  }, [allProjects, filteredProgramme]);
+
+  const selected = useMemo(
+    () => projects.find((p) => p.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId],
+  );
+
+  // When the visible-project list changes (filter applied/removed), make sure
+  // we pick a project that's actually in it.
+  useEffect(() => {
+    if (projects.length === 0) return;
+    if (!projects.some((p) => p.id === selectedProjectId)) {
+      setSelectedProjectId(projects[0].id);
+    }
+  }, [projects, selectedProjectId]);
+
+  const clearProgrammeFilter = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("programme");
+    setSearchParams(next);
+  };
+
+  const programmeByProject = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const p of programmes.data ?? []) {
+      map.set(p.id, p.currency_code);
+    }
+    return map;
+  }, [programmes.data]);
+
+  const evm = useQuery({
+    queryKey: ["evm", selected?.id ?? null],
+    queryFn: () => (selected ? fetchEvm(selected.id) : Promise.resolve([])),
+    enabled: selected !== null,
+  });
+
+  const sourceCurrency =
+    (selected && selected.program_id && programmeByProject.get(selected.program_id)) ||
+    "USD";
+
+  const evmTrend = useMemo(() => {
+    const rows = evm.data ?? [];
+    return rows.map((r) => ({
+      month: r.snapshot_date.slice(0, 7),
+      monthLabel: shortMonth(r.snapshot_date),
+      cpi: r.cpi,
+      spi: r.spi,
+    }));
+  }, [evm.data]);
+
+  if (programmes.isLoading || allProjectsQuery.isLoading) {
+    return <p className="text-sm text-navy/60">Loading projects…</p>;
+  }
+
+  if (projects.length === 0) {
+    return (
+      <Card>
+        <CardHeader title="No projects yet" />
+        <p className="text-sm text-navy/60">
+          Seed the NovaTech demo or import <code>projects.csv</code> to see
+          Delivery Health.
+        </p>
+      </Card>
+    );
+  }
+
+  const selectedProgrammeCode =
+    (selected && programmes.data?.find((p) => p.id === selected.program_id)?.code) ||
+    filteredProgramme?.code ||
+    null;
+
+  // Drill-across helpers: prev/next project, wrapping at both ends.
+  const selectedIdx = selected
+    ? projects.findIndex((p) => p.id === selected.id)
+    : -1;
+  const prevProject =
+    selectedIdx > 0
+      ? projects[selectedIdx - 1]
+      : projects.length > 0
+        ? projects[projects.length - 1]
+        : null;
+  const nextProject =
+    selectedIdx >= 0 && selectedIdx < projects.length - 1
+      ? projects[selectedIdx + 1]
+      : projects.length > 0
+        ? projects[0]
+        : null;
+
+  const breadcrumbItems = [
+    { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
+    { label: "Delivery Health", to: filteredProgramme ? "/delivery" : undefined },
+    ...(filteredProgramme
+      ? [
+          {
+            label: filteredProgramme.name,
+            to: selected ? `/delivery?programme=${filteredProgramme.code}` : undefined,
+          },
+        ]
+      : []),
+    ...(selected ? [{ label: selected.code }] : []),
+  ];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Breadcrumb items={breadcrumbItems} />
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-navy">Delivery Health</h1>
+          <p className="mt-1 text-sm text-navy/70">
+            Methodology-adaptive view. Pick a project below — the page reshapes
+            to Scrum, Kanban or Waterfall based on the project's{" "}
+            <code>delivery_methodology</code>.
+          </p>
+        </div>
+        {selectedProgrammeCode ? (
+          <Link
+            to={`/kpi?programme=${selectedProgrammeCode}`}
+            className="btn-ghost"
+          >
+            <Layers className="size-3" /> View KPIs for {selectedProgrammeCode}
+          </Link>
+        ) : null}
+      </div>
+
+      {filteredProgramme ? (
+        <div className="inline-flex items-center gap-2 self-start rounded-full border border-navy/30 bg-navy/5 px-3 py-1 text-xs text-navy">
+          Filtered to <strong>{filteredProgramme.name}</strong>
+          <button
+            type="button"
+            onClick={clearProgrammeFilter}
+            className="inline-flex items-center rounded-full bg-navy/10 px-1.5 py-0.5 transition hover:bg-navy/20"
+            aria-label="Clear programme filter (drill up)"
+          >
+            <X className="size-3" /> clear
+          </button>
+        </div>
+      ) : null}
+
+      <Card>
+        <CardHeader
+          title="Project picker"
+          subtitle={`${projects.length} ${filteredProgramme ? "matching" : ""} project${projects.length === 1 ? "" : "s"}`}
+          action={
+            projects.length > 1 && selected ? (
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() =>
+                    prevProject && setSelectedProjectId(prevProject.id)
+                  }
+                  disabled={!prevProject}
+                  className="btn-ghost px-2 py-1 text-xs"
+                  aria-label="Previous project (drill across)"
+                >
+                  <ChevronLeft className="size-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    nextProject && setSelectedProjectId(nextProject.id)
+                  }
+                  disabled={!nextProject}
+                  className="btn-ghost px-2 py-1 text-xs"
+                  aria-label="Next project (drill across)"
+                >
+                  <ChevronRight className="size-3" />
+                </button>
+              </div>
+            ) : null
+          }
+        />
+        <div className="flex flex-wrap gap-2">
+          {projects.map((p) => {
+            const isActive = p.id === selectedProjectId;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setSelectedProjectId(p.id)}
+                className={`rounded-md border px-3 py-2 text-left text-sm transition ${
+                  isActive
+                    ? "border-navy bg-navy text-white"
+                    : "border-ice-100 bg-white text-navy hover:bg-ice-50"
+                }`}
+              >
+                <div className="font-medium">{p.code}</div>
+                <div className="mt-0.5 flex items-center gap-2 text-xs">
+                  <Badge tone={METHODOLOGY_TONE[p.delivery_methodology] ?? "neutral"}>
+                    {p.delivery_methodology}
+                  </Badge>
+                  {p.is_ai_augmented ? (
+                    <span className="text-amber-500">AI</span>
+                  ) : null}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </Card>
+
+      {selected ? (
+        <>
+          <Card>
+            <CardHeader
+              title={selected.name}
+              subtitle={`Programme ${programmes.data?.find((p) => p.id === selected.program_id)?.code ?? "—"} · ${selected.delivery_methodology}`}
+              action={<Badge tone="neutral">{selected.status}</Badge>}
+            />
+            <EvmStrip
+              evm={evm.data ?? []}
+              project={selected}
+              sourceCurrency={sourceCurrency}
+            />
+          </Card>
+
+          <Card>
+            <CardHeader
+              title="EVM trend"
+              subtitle="12-month CPI and SPI"
+            />
+            <div className="h-72">
+              {evmTrend.length === 0 ? (
+                <p className="grid h-full place-items-center text-sm text-navy/60">
+                  No EVM snapshots for this project yet.
+                </p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart
+                    data={evmTrend}
+                    margin={{ top: 8, right: 24, left: 0, bottom: 8 }}
+                  >
+                    <CartesianGrid stroke="#E4EEF4" strokeDasharray="4 4" />
+                    <XAxis dataKey="monthLabel" stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+                    <YAxis
+                      stroke="#1B2A4A"
+                      tick={{ fontSize: 12 }}
+                      tickFormatter={(v) => formatRatio(Number(v))}
+                    />
+                    <Tooltip
+                      formatter={(v: number) => formatRatio(v)}
+                      contentStyle={{ border: "1px solid #D5E8F0" }}
+                    />
+                    <Legend wrapperStyle={{ fontSize: 12 }} />
+                    <Line
+                      type="monotone"
+                      dataKey="cpi"
+                      name="CPI"
+                      stroke="#1B2A4A"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="spi"
+                      name="SPI"
+                      stroke="#F59E0B"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          {selected.delivery_methodology === "Scrum" ? (
+            <ScrumView project={selected} />
+          ) : selected.delivery_methodology === "Kanban" ? (
+            <KanbanView project={selected} />
+          ) : selected.delivery_methodology === "Waterfall" ? (
+            <WaterfallView project={selected} />
+          ) : (
+            <Card>
+              <p className="text-sm text-navy/60">
+                {selected.delivery_methodology} view is scheduled for a future
+                iteration. Scrum, Kanban and Waterfall views are live today.
+              </p>
+            </Card>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function shortMonth(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-GB", { month: "short", year: "2-digit" });
+}

--- a/frontend/src/pages/ExecutiveOverview.tsx
+++ b/frontend/src/pages/ExecutiveOverview.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   CartesianGrid,
   Legend,
@@ -9,7 +10,8 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { FileDown, Sparkles } from "lucide-react";
+import { ChevronRight, FileDown, Home, Sparkles } from "lucide-react";
+import { Breadcrumb } from "@/components/Breadcrumb";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { KpiTile } from "@/components/ui/KpiTile";
@@ -48,6 +50,7 @@ function deriveBucket(margin: number | null, status: string): RagBucket {
 }
 
 export function ExecutiveOverview() {
+  const navigate = useNavigate();
   const programmes = useProgrammes();
   const margin = useMarginSnapshots();
   const cpi = useCpiSnapshots();
@@ -110,6 +113,13 @@ export function ExecutiveOverview() {
     [buckets, totals, rows, currency.baseCurrency],
   );
 
+  const [ragFilter, setRagFilter] = useState<RagBucket | null>(null);
+
+  const visibleRows = useMemo(() => {
+    if (ragFilter === null) return rows;
+    return rows.filter((r) => deriveBucket(r.latestMargin, r.status) === ragFilter);
+  }, [rows, ragFilter]);
+
   const loading =
     programmes.isLoading || margin.isLoading || cpi.isLoading;
   const error = programmes.error ?? margin.error ?? cpi.error;
@@ -136,6 +146,15 @@ export function ExecutiveOverview() {
 
   return (
     <div className="flex flex-col gap-6">
+      <Breadcrumb
+        items={[
+          {
+            label: "Portfolio",
+            icon: <Home className="size-3" aria-hidden="true" />,
+          },
+          { label: "Executive Summary" },
+        ]}
+      />
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold text-navy">Executive Summary</h1>
@@ -151,11 +170,32 @@ export function ExecutiveOverview() {
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
         <Card>
-          <CardHeader title="Portfolio Health" subtitle="RAG roll-up across programmes" />
+          <CardHeader
+            title="Portfolio Health"
+            subtitle="Click a bucket to filter the table below"
+          />
           <div className="flex items-center justify-around gap-3 pt-1 text-center">
-            <RagStat count={buckets.green} label="Green" tone="green" />
-            <RagStat count={buckets.amber} label="Amber" tone="amber" />
-            <RagStat count={buckets.red} label="Red" tone="red" />
+            <RagStat
+              count={buckets.green}
+              label="Green"
+              tone="green"
+              active={ragFilter === "green"}
+              onClick={() => setRagFilter(ragFilter === "green" ? null : "green")}
+            />
+            <RagStat
+              count={buckets.amber}
+              label="Amber"
+              tone="amber"
+              active={ragFilter === "amber"}
+              onClick={() => setRagFilter(ragFilter === "amber" ? null : "amber")}
+            />
+            <RagStat
+              count={buckets.red}
+              label="Red"
+              tone="red"
+              active={ragFilter === "red"}
+              onClick={() => setRagFilter(ragFilter === "red" ? null : "red")}
+            />
           </div>
           <p className="mt-4 text-xs text-navy/60">
             Derived from programme status and the latest monthly margin KPI.
@@ -267,7 +307,22 @@ export function ExecutiveOverview() {
 
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <Card className="lg:col-span-2">
-          <CardHeader title="Programme status" subtitle="Margin and CPI by programme" />
+          <CardHeader
+            title="Programme status"
+            subtitle="Click any row to drill into Delivery Health for that programme"
+            action={
+              ragFilter ? (
+                <button
+                  type="button"
+                  onClick={() => setRagFilter(null)}
+                  className="inline-flex items-center gap-1 rounded-full border border-navy/30 px-2 py-0.5 text-xs text-navy hover:bg-ice-50"
+                >
+                  {ragFilter} only
+                  <span aria-hidden="true">×</span>
+                </button>
+              ) : null
+            }
+          />
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
@@ -277,13 +332,34 @@ export function ExecutiveOverview() {
                   <th className="text-right">Revenue</th>
                   <th className="text-right">Margin</th>
                   <th className="text-right">CPI</th>
+                  <th aria-hidden="true" />
                 </tr>
               </thead>
               <tbody>
-                {rows.map((r) => {
+                {visibleRows.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="py-6 text-center text-xs text-navy/60">
+                      No programmes match the {ragFilter} filter.
+                    </td>
+                  </tr>
+                ) : null}
+                {visibleRows.map((r) => {
                   const tone = deriveBucket(r.latestMargin, r.status);
                   return (
-                    <tr key={r.code} className="border-t border-ice-100">
+                    <tr
+                      key={r.code}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => navigate(`/delivery?programme=${r.code}`)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          navigate(`/delivery?programme=${r.code}`);
+                        }
+                      }}
+                      className="cursor-pointer border-t border-ice-100 transition hover:bg-ice-50 focus-visible:bg-ice-50"
+                      aria-label={`Drill into ${r.name}`}
+                    >
                       <td className="py-2 font-medium">{r.name}</td>
                       <td>
                         <Badge tone={tone}>{r.status}</Badge>
@@ -296,6 +372,9 @@ export function ExecutiveOverview() {
                       </td>
                       <td className="text-right font-mono">
                         {formatRatio(r.latestCpi)}
+                      </td>
+                      <td className="pr-2 text-right text-navy/40">
+                        <ChevronRight className="inline size-4" aria-hidden="true" />
                       </td>
                     </tr>
                   );
@@ -322,14 +401,34 @@ export function ExecutiveOverview() {
   );
 }
 
-function RagStat({ count, label, tone }: { count: number; label: string; tone: RagBucket }) {
+function RagStat({
+  count,
+  label,
+  tone,
+  active,
+  onClick,
+}: {
+  count: number;
+  label: string;
+  tone: RagBucket;
+  active?: boolean;
+  onClick?: () => void;
+}) {
   return (
-    <div className="flex flex-col items-center gap-1">
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={`Filter to ${count} ${label} programmes`}
+      className={`flex flex-col items-center gap-1 rounded-lg px-2 py-1 transition ${
+        active ? "bg-navy/5 ring-2 ring-navy/40" : "hover:bg-ice-50"
+      }`}
+    >
       <Badge tone={tone} className="px-3 py-1 text-sm">
         {count}
       </Badge>
       <span className="text-xs text-navy/60">{label}</span>
-    </div>
+    </button>
   );
 }
 

--- a/frontend/src/pages/KpiStudio.tsx
+++ b/frontend/src/pages/KpiStudio.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   CartesianGrid,
@@ -11,7 +12,8 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { BookOpen, Pencil, Save, X } from "lucide-react";
+import { BookOpen, ChevronRight, Home, Pencil, Save, X } from "lucide-react";
+import { Breadcrumb } from "@/components/Breadcrumb";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import {
@@ -50,6 +52,9 @@ function formatValue(value: number, kpi: KpiDefinition): string {
 
 export function KpiStudio() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const programmeFilter = searchParams.get("programme");
   const [selectedKpiId, setSelectedKpiId] = useState<number | null>(null);
   const [formulaOpen, setFormulaOpen] = useState(false);
   const [editingWeight, setEditingWeight] = useState<{ id: number; value: string } | null>(null);
@@ -75,14 +80,35 @@ export function KpiStudio() {
     }
   }, [definitions.data, selectedKpi]);
 
+  // When a programme filter is set, pass it through to the snapshot query so
+  // the chart + table focus on a single programme for drill-down.
+  const filteredProgramme = useMemo(
+    () => programmes.data?.find((p) => p.code === programmeFilter) ?? null,
+    [programmes.data, programmeFilter],
+  );
+
   const snapshots = useQuery({
-    queryKey: ["kpi-snapshots", "studio", selectedKpi?.code ?? null],
+    queryKey: [
+      "kpi-snapshots",
+      "studio",
+      selectedKpi?.code ?? null,
+      filteredProgramme?.id ?? null,
+    ],
     queryFn: () =>
       selectedKpi
-        ? fetchKpiSnapshots({ kpiCode: selectedKpi.code })
+        ? fetchKpiSnapshots({
+            kpiCode: selectedKpi.code,
+            programId: filteredProgramme?.id,
+          })
         : Promise.resolve([]),
     enabled: selectedKpi !== null,
   });
+
+  const clearProgrammeFilter = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("programme");
+    setSearchParams(next);
+  };
 
   const weightMutation = useMutation({
     mutationFn: ({ id, weight }: { id: number; weight: number }) =>
@@ -145,8 +171,46 @@ export function KpiStudio() {
     return <p className="text-sm text-danger-600">{(definitions.error as Error).message}</p>;
   }
 
+  const breadcrumbItems = [
+    { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
+    { label: "KPI Studio", to: filteredProgramme || selectedKpi ? "/kpi" : undefined },
+    ...(filteredProgramme
+      ? [
+          {
+            label: filteredProgramme.name,
+            to: selectedKpi ? `/kpi?programme=${filteredProgramme.code}` : undefined,
+          },
+        ]
+      : []),
+    ...(selectedKpi ? [{ label: selectedKpi.name }] : []),
+  ];
+
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
+    <div className="flex flex-col gap-4">
+      <Breadcrumb items={breadcrumbItems} />
+
+      {filteredProgramme ? (
+        <div className="inline-flex items-center gap-2 self-start rounded-full border border-navy/30 bg-navy/5 px-3 py-1 text-xs text-navy">
+          Focused on <strong>{filteredProgramme.name}</strong>
+          <button
+            type="button"
+            onClick={clearProgrammeFilter}
+            className="inline-flex items-center rounded-full bg-navy/10 px-1.5 py-0.5 transition hover:bg-navy/20"
+            aria-label="Clear programme filter (drill up)"
+          >
+            <X className="size-3" /> clear
+          </button>
+          <Link
+            to={`/delivery?programme=${filteredProgramme.code}`}
+            className="ml-1 inline-flex items-center gap-1 text-navy hover:underline"
+          >
+            View in Delivery Health
+            <ChevronRight className="size-3" />
+          </Link>
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
       <aside className="flex flex-col gap-4">
         <Card>
           <CardHeader
@@ -372,7 +436,10 @@ export function KpiStudio() {
             </Card>
 
             <Card>
-              <CardHeader title="Latest values" subtitle="Most recent snapshot per programme" />
+              <CardHeader
+                title="Latest values"
+                subtitle="Click any programme to drill into Delivery Health"
+              />
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
@@ -380,6 +447,7 @@ export function KpiStudio() {
                       <th className="py-2">Programme</th>
                       <th className="text-right">Latest</th>
                       <th className="text-right">Status</th>
+                      <th aria-hidden="true" />
                     </tr>
                   </thead>
                   <tbody>
@@ -388,13 +456,29 @@ export function KpiStudio() {
                       if (latest === null) return null;
                       const tone = thresholdTone(latest, selectedKpi);
                       return (
-                        <tr key={p.id} className="border-t border-ice-100">
+                        <tr
+                          key={p.id}
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => navigate(`/delivery?programme=${p.code}`)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              navigate(`/delivery?programme=${p.code}`);
+                            }
+                          }}
+                          className="cursor-pointer border-t border-ice-100 transition hover:bg-ice-50 focus-visible:bg-ice-50"
+                          aria-label={`Drill into ${p.name}`}
+                        >
                           <td className="py-2 font-medium">{p.code}</td>
                           <td className="text-right font-mono">
                             {formatValue(latest, selectedKpi)}
                           </td>
                           <td className="text-right">
                             <Badge tone={tone}>{tone}</Badge>
+                          </td>
+                          <td className="pr-2 text-right text-navy/40">
+                            <ChevronRight className="inline size-4" aria-hidden="true" />
                           </td>
                         </tr>
                       );
@@ -414,6 +498,7 @@ export function KpiStudio() {
       {formulaOpen && selectedKpi ? (
         <FormulaModal kpi={selectedKpi} onClose={() => setFormulaOpen(false)} />
       ) : null}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/delivery/EvmStrip.tsx
+++ b/frontend/src/pages/delivery/EvmStrip.tsx
@@ -1,0 +1,85 @@
+import { useCurrency } from "@/hooks/useCurrency";
+import type { EvmSnapshot, ProjectListItem } from "@/lib/api";
+import { formatPct, formatRatio, type RagBucket } from "@/lib/format";
+import { Badge } from "@/components/ui/Badge";
+
+export function EvmStrip({
+  evm,
+  project,
+  sourceCurrency,
+}: {
+  evm: EvmSnapshot[];
+  project: ProjectListItem;
+  sourceCurrency: string;
+}) {
+  const currency = useCurrency();
+  const latest = evm.length > 0 ? evm[evm.length - 1] : null;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+      <EvmCell
+        label="CPI"
+        value={formatRatio(latest?.cpi)}
+        tone={toneForIndex(latest?.cpi ?? null)}
+      />
+      <EvmCell
+        label="SPI"
+        value={formatRatio(latest?.spi)}
+        tone={toneForIndex(latest?.spi ?? null)}
+      />
+      <EvmCell
+        label="EAC"
+        value={currency.format(latest?.eac ?? null, sourceCurrency)}
+        sub={`BAC ${currency.format(project.id ? latest?.bac ?? null : null, sourceCurrency)}`}
+      />
+      <EvmCell
+        label="TCPI"
+        value={formatRatio(latest?.tcpi)}
+        tone={toneForIndex(latest?.tcpi ?? null, true)}
+      />
+      <EvmCell
+        label="% Complete"
+        value={formatPct(latest ? (latest.percent_complete ?? 0) / 100 : null)}
+      />
+    </div>
+  );
+}
+
+function toneForIndex(
+  value: number | null,
+  isTcpi = false,
+): RagBucket | "neutral" {
+  if (value === null) return "neutral";
+  // CPI/SPI: ≥1.0 green, 0.9–1.0 amber, <0.9 red
+  // TCPI: <1.05 green, 1.05–1.15 amber, >1.15 red (higher = more work per $)
+  if (isTcpi) {
+    if (value <= 1.05) return "green";
+    if (value <= 1.15) return "amber";
+    return "red";
+  }
+  if (value >= 1.0) return "green";
+  if (value >= 0.9) return "amber";
+  return "red";
+}
+
+function EvmCell({
+  label,
+  value,
+  sub,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: RagBucket | "neutral";
+}) {
+  return (
+    <div className="flex flex-col gap-1 rounded border border-ice-100 bg-white px-3 py-2">
+      <span className="kpi-label">{label}</span>
+      <div className="flex items-center gap-2">
+        <Badge tone={tone}>{value}</Badge>
+      </div>
+      {sub ? <span className="text-xs text-navy/60">{sub}</span> : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/delivery/KanbanView.tsx
+++ b/frontend/src/pages/delivery/KanbanView.tsx
@@ -1,0 +1,234 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import ReactECharts from "echarts-for-react";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { fetchFlow, type ProjectListItem } from "@/lib/api";
+
+export function KanbanView({ project }: { project: ProjectListItem }) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["flow", project.id],
+    queryFn: () => fetchFlow(project.id),
+  });
+
+  const sorted = useMemo(() => {
+    if (!data) return [];
+    return data
+      .slice()
+      .sort((a, b) =>
+        (a.period_start ?? "").localeCompare(b.period_start ?? ""),
+      );
+  }, [data]);
+
+  const cfdOption = useMemo(() => buildCfdOption(sorted), [sorted]);
+  const cycleOption = useMemo(() => buildCyclePercentileOption(sorted), [sorted]);
+
+  if (isLoading) return <p className="text-sm text-navy/60">Loading flow metrics…</p>;
+  if (error)
+    return (
+      <p className="text-sm text-danger-600">{(error as Error).message}</p>
+    );
+  if (sorted.length === 0) {
+    return (
+      <p className="text-sm text-navy/60">
+        No flow metrics seeded for this project.
+      </p>
+    );
+  }
+
+  const latest = sorted[sorted.length - 1];
+  const avgThroughput =
+    sorted.reduce((sum, r) => sum + (r.throughput_items ?? 0), 0) / sorted.length;
+  const wipBreach =
+    latest.wip_avg !== null &&
+    latest.wip_limit !== null &&
+    latest.wip_avg > latest.wip_limit;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <FlowStat
+          label="Throughput (this wk)"
+          value={`${latest.throughput_items ?? 0}`}
+          sub={`avg ${avgThroughput.toFixed(1)}`}
+        />
+        <FlowStat
+          label="WIP avg"
+          value={`${(latest.wip_avg ?? 0).toFixed(1)}`}
+          sub={`limit ${latest.wip_limit ?? "—"}`}
+          tone={wipBreach ? "red" : "green"}
+        />
+        <FlowStat
+          label="Cycle time p50"
+          value={`${(latest.cycle_time_p50 ?? 0).toFixed(1)}d`}
+          sub={`p95 ${(latest.cycle_time_p95 ?? 0).toFixed(1)}d`}
+        />
+        <FlowStat
+          label="Blocked"
+          value={`${(latest.blocked_time_hours ?? 0).toFixed(1)}h`}
+        />
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Cumulative flow diagram"
+          subtitle="Approximate CFD built from per-week WIP and throughput"
+        />
+        <div className="h-80">
+          <ReactECharts
+            option={cfdOption}
+            style={{ height: "100%", width: "100%" }}
+            notMerge
+          />
+        </div>
+        <p className="mt-2 text-xs text-navy/60">
+          CFD = stacked backlog + in-progress + done. Widening bands →
+          growing WIP or slowing throughput; look at the In Progress
+          layer's thickness vs. Done's slope.
+        </p>
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="Cycle-time percentiles"
+          subtitle="p50 / p85 / p95 per week (days)"
+        />
+        <div className="h-72">
+          <ReactECharts
+            option={cycleOption}
+            style={{ height: "100%", width: "100%" }}
+            notMerge
+          />
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function FlowStat({
+  label,
+  value,
+  sub,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: "green" | "amber" | "red" | "neutral";
+}) {
+  return (
+    <div className="rounded border border-ice-100 bg-white px-3 py-2">
+      <span className="kpi-label">{label}</span>
+      <div className="flex items-center gap-2">
+        <p className="font-mono text-xl font-semibold text-navy">{value}</p>
+        {tone !== "neutral" ? <Badge tone={tone}>·</Badge> : null}
+      </div>
+      {sub ? <p className="text-xs text-navy/60">{sub}</p> : null}
+    </div>
+  );
+}
+
+function buildCfdOption(
+  rows: { period_start: string | null; throughput_items: number | null; wip_avg: number | null }[],
+) {
+  const weeks = rows.map((r) => weekLabel(r.period_start));
+  const doneRunning: number[] = [];
+  let running = 0;
+  for (const r of rows) {
+    running += r.throughput_items ?? 0;
+    doneRunning.push(running);
+  }
+  const inProgress = rows.map((r) => r.wip_avg ?? 0);
+  // Synthesise backlog so the topmost band expands with WIP pressure.
+  const backlog = rows.map((_, i) =>
+    Math.max(5, inProgress[i] * 1.3 + (i * 0.8)),
+  );
+
+  return {
+    tooltip: { trigger: "axis" },
+    legend: { data: ["Done (cumulative)", "In Progress", "Backlog"], bottom: 0 },
+    grid: { top: 20, right: 20, bottom: 40, left: 50 },
+    xAxis: { type: "category", data: weeks, boundaryGap: false },
+    yAxis: { type: "value", name: "Items" },
+    series: [
+      {
+        name: "Done (cumulative)",
+        type: "line",
+        stack: "cfd",
+        areaStyle: { color: "#10B981", opacity: 0.8 },
+        lineStyle: { width: 0 },
+        symbol: "none",
+        data: doneRunning,
+      },
+      {
+        name: "In Progress",
+        type: "line",
+        stack: "cfd",
+        areaStyle: { color: "#F59E0B", opacity: 0.7 },
+        lineStyle: { width: 0 },
+        symbol: "none",
+        data: inProgress,
+      },
+      {
+        name: "Backlog",
+        type: "line",
+        stack: "cfd",
+        areaStyle: { color: "#1B2A4A", opacity: 0.15 },
+        lineStyle: { width: 0 },
+        symbol: "none",
+        data: backlog,
+      },
+    ],
+  };
+}
+
+function buildCyclePercentileOption(
+  rows: {
+    period_start: string | null;
+    cycle_time_p50: number | null;
+    cycle_time_p85: number | null;
+    cycle_time_p95: number | null;
+  }[],
+) {
+  const weeks = rows.map((r) => weekLabel(r.period_start));
+  return {
+    tooltip: { trigger: "axis" },
+    legend: { data: ["p50", "p85", "p95"], bottom: 0 },
+    grid: { top: 20, right: 20, bottom: 40, left: 50 },
+    xAxis: { type: "category", data: weeks },
+    yAxis: { type: "value", name: "Days" },
+    series: [
+      {
+        name: "p50",
+        type: "line",
+        smooth: true,
+        lineStyle: { color: "#10B981", width: 2 },
+        itemStyle: { color: "#10B981" },
+        data: rows.map((r) => r.cycle_time_p50 ?? 0),
+      },
+      {
+        name: "p85",
+        type: "line",
+        smooth: true,
+        lineStyle: { color: "#F59E0B", width: 2 },
+        itemStyle: { color: "#F59E0B" },
+        data: rows.map((r) => r.cycle_time_p85 ?? 0),
+      },
+      {
+        name: "p95",
+        type: "line",
+        smooth: true,
+        lineStyle: { color: "#EF4444", width: 2 },
+        itemStyle: { color: "#EF4444" },
+        data: rows.map((r) => r.cycle_time_p95 ?? 0),
+      },
+    ],
+  };
+}
+
+function weekLabel(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-GB", { day: "2-digit", month: "short" });
+}

--- a/frontend/src/pages/delivery/ScrumView.tsx
+++ b/frontend/src/pages/delivery/ScrumView.tsx
@@ -1,0 +1,272 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { fetchSprints, type ProjectListItem } from "@/lib/api";
+import { formatDate } from "@/lib/format";
+
+export function ScrumView({ project }: { project: ProjectListItem }) {
+  const [expandedSprint, setExpandedSprint] = useState<number | null>(null);
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["sprints", project.id],
+    queryFn: () => fetchSprints(project.id),
+  });
+
+  if (isLoading) return <p className="text-sm text-navy/60">Loading sprints…</p>;
+  if (error)
+    return (
+      <p className="text-sm text-danger-600">{(error as Error).message}</p>
+    );
+  if (!data || data.length === 0) {
+    return (
+      <p className="text-sm text-navy/60">
+        No sprint data seeded for this project.
+      </p>
+    );
+  }
+
+  const sprints = data.slice().sort(
+    (a, b) => (a.sprint_number ?? 0) - (b.sprint_number ?? 0),
+  );
+  const chartData = sprints.map((s) => ({
+    sprint: `#${s.sprint_number ?? "?"}`,
+    planned: s.planned_points ?? 0,
+    completed: s.completed_points ?? 0,
+    velocity: s.velocity ?? 0,
+    rework: s.rework_hours ?? 0,
+    defectsFound: s.defects_found ?? 0,
+    aiAssisted: s.ai_assisted_points,
+  }));
+
+  const lastSprint = sprints[sprints.length - 1];
+  const avgVelocity =
+    sprints.reduce((sum, s) => sum + (s.velocity ?? 0), 0) / sprints.length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <SprintStat label="Last sprint" value={`#${lastSprint.sprint_number ?? "?"}`} />
+        <SprintStat
+          label="Velocity"
+          value={`${(lastSprint.velocity ?? 0).toFixed(0)} pts`}
+          sub={`avg ${avgVelocity.toFixed(0)}`}
+        />
+        <SprintStat
+          label="Defects found"
+          value={`${lastSprint.defects_found ?? 0}`}
+        />
+        <SprintStat
+          label="Rework hrs"
+          value={`${(lastSprint.rework_hours ?? 0).toFixed(0)}h`}
+        />
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Planned vs completed points"
+          subtitle="Each bar pair is one sprint"
+        />
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={{ top: 8, right: 20, left: 0, bottom: 8 }}>
+              <CartesianGrid stroke="#E4EEF4" strokeDasharray="4 4" />
+              <XAxis dataKey="sprint" stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+              <YAxis stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+              <Tooltip contentStyle={{ border: "1px solid #D5E8F0" }} />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Bar dataKey="planned" name="Planned" fill="#D5E8F0" />
+              <Bar dataKey="completed" name="Completed" fill="#1B2A4A" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="Velocity trend + quality burden"
+          subtitle="Line = velocity; bars = rework hours and defects"
+        />
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={chartData} margin={{ top: 8, right: 20, left: 0, bottom: 8 }}>
+              <CartesianGrid stroke="#E4EEF4" strokeDasharray="4 4" />
+              <XAxis dataKey="sprint" stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+              <YAxis yAxisId="left" stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                stroke="#F59E0B"
+                tick={{ fontSize: 12 }}
+              />
+              <Tooltip contentStyle={{ border: "1px solid #D5E8F0" }} />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Bar
+                yAxisId="right"
+                dataKey="rework"
+                name="Rework hrs"
+                fill="#FCD8A3"
+              />
+              <Bar
+                yAxisId="right"
+                dataKey="defectsFound"
+                name="Defects"
+                fill="#FCA5A5"
+              />
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="velocity"
+                name="Velocity"
+                stroke="#1B2A4A"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+
+      {project.is_ai_augmented ? (
+        <Card>
+          <CardHeader
+            title="Dual velocity"
+            subtitle={`AI augmentation level: ${project.ai_augmentation_level ?? "—"}`}
+            action={
+              <Badge tone="amber">AI augmented</Badge>
+            }
+          />
+          <div className="h-60">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} margin={{ top: 8, right: 20, left: 0, bottom: 8 }}>
+                <CartesianGrid stroke="#E4EEF4" strokeDasharray="4 4" />
+                <XAxis dataKey="sprint" stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+                <YAxis stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+                <Tooltip contentStyle={{ border: "1px solid #D5E8F0" }} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar dataKey="completed" name="Total points" fill="#1B2A4A" />
+                <Bar dataKey="aiAssisted" name="AI-assisted points" fill="#F59E0B" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <p className="mt-2 text-xs text-navy/60">
+            Track AI-assisted points alongside standard velocity so trust-score
+            and quality-parity dashboards in Tab 7 stay honest.
+          </p>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader
+          title="Sprint ledger"
+          subtitle="Click a sprint to expand full detail"
+        />
+        <ul className="flex flex-col divide-y divide-ice-100">
+          {sprints.map((s) => {
+            const isOpen = expandedSprint === s.sprint_number;
+            const burndownPct =
+              s.planned_points && s.planned_points > 0
+                ? Math.round(((s.completed_points ?? 0) / s.planned_points) * 100)
+                : 0;
+            return (
+              <li key={s.id}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setExpandedSprint(
+                      isOpen ? null : (s.sprint_number ?? null),
+                    )
+                  }
+                  aria-expanded={isOpen}
+                  className="grid w-full grid-cols-[auto_1fr_auto] items-center gap-3 py-3 text-left text-sm transition hover:bg-ice-50"
+                >
+                  <span className="font-mono text-xs text-navy/60">
+                    Sprint #{s.sprint_number ?? "?"}
+                  </span>
+                  <span>
+                    {s.completed_points ?? 0} / {s.planned_points ?? 0} pts ·{" "}
+                    {s.defects_found ?? 0} defects · {burndownPct}% of plan
+                  </span>
+                  {isOpen ? (
+                    <ChevronUp className="size-4 text-navy/40" aria-hidden="true" />
+                  ) : (
+                    <ChevronDown className="size-4 text-navy/40" aria-hidden="true" />
+                  )}
+                </button>
+                {isOpen ? (
+                  <dl className="grid grid-cols-2 gap-3 pb-3 pl-4 text-sm md:grid-cols-4">
+                    <DetailCell
+                      label="Dates"
+                      value={`${formatDate(s.start_date)} → ${formatDate(s.end_date)}`}
+                    />
+                    <DetailCell label="Team size" value={`${s.team_size ?? "—"}`} />
+                    <DetailCell label="Velocity" value={`${(s.velocity ?? 0).toFixed(0)} pts`} />
+                    <DetailCell
+                      label="Rework"
+                      value={`${(s.rework_hours ?? 0).toFixed(1)}h`}
+                    />
+                    <DetailCell
+                      label="Defects found / fixed"
+                      value={`${s.defects_found ?? 0} / ${s.defects_fixed ?? 0}`}
+                    />
+                    <DetailCell
+                      label="AI-assisted"
+                      value={`${s.ai_assisted_points} pts`}
+                    />
+                    <DetailCell
+                      label="Estimation"
+                      value={s.estimation_unit}
+                    />
+                    <DetailCell
+                      label="Iteration type"
+                      value={s.iteration_type}
+                    />
+                  </dl>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      </Card>
+    </div>
+  );
+}
+
+function DetailCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="kpi-label">{label}</span>
+      <span className="font-mono text-sm text-navy">{value}</span>
+    </div>
+  );
+}
+
+function SprintStat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded border border-ice-100 bg-white px-3 py-2">
+      <span className="kpi-label">{label}</span>
+      <p className="font-mono text-xl font-semibold text-navy">{value}</p>
+      {sub ? <p className="text-xs text-navy/60">{sub}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/delivery/WaterfallView.tsx
+++ b/frontend/src/pages/delivery/WaterfallView.tsx
@@ -1,0 +1,242 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { fetchPhases, fetchMilestones, type ProjectListItem } from "@/lib/api";
+import { formatDate, type RagBucket } from "@/lib/format";
+
+const GATE_TONE: Record<string, RagBucket | "neutral"> = {
+  passed: "green",
+  failed: "red",
+  conditional: "amber",
+  pending: "neutral",
+};
+
+const STATUS_TONE: Record<string, RagBucket | "neutral"> = {
+  Completed: "green",
+  "In Progress": "amber",
+  Pending: "neutral",
+  Delayed: "red",
+  "At Risk": "red",
+};
+
+export function WaterfallView({ project }: { project: ProjectListItem }) {
+  const [expandedPhase, setExpandedPhase] = useState<number | null>(null);
+  const [expandedMilestone, setExpandedMilestone] = useState<number | null>(null);
+
+  const phases = useQuery({
+    queryKey: ["phases", project.id],
+    queryFn: () => fetchPhases(project.id),
+  });
+  const milestones = useQuery({
+    queryKey: ["milestones", project.id],
+    queryFn: () => fetchMilestones(project.id),
+  });
+
+  const isLoading = phases.isLoading || milestones.isLoading;
+  const error = phases.error ?? milestones.error;
+
+  if (isLoading)
+    return <p className="text-sm text-navy/60">Loading phases + milestones…</p>;
+  if (error)
+    return (
+      <p className="text-sm text-danger-600">{(error as Error).message}</p>
+    );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader
+          title="Phase timeline"
+          subtitle="Planned vs actual per phase with gate status"
+        />
+        <ol className="flex flex-col divide-y divide-ice-100">
+          {(phases.data ?? []).map((phase) => {
+            const plannedDurationMs =
+              phase.planned_start && phase.planned_end
+                ? new Date(phase.planned_end).getTime() -
+                  new Date(phase.planned_start).getTime()
+                : 0;
+            const actualDurationMs =
+              phase.actual_start
+                ? (phase.actual_end
+                    ? new Date(phase.actual_end).getTime()
+                    : Date.now()) - new Date(phase.actual_start).getTime()
+                : 0;
+            const varianceDays =
+              actualDurationMs && plannedDurationMs
+                ? Math.round(
+                    (actualDurationMs - plannedDurationMs) / (1000 * 60 * 60 * 24),
+                  )
+                : null;
+            const isOpen = expandedPhase === phase.id;
+            return (
+              <li key={phase.id}>
+                <button
+                  type="button"
+                  onClick={() => setExpandedPhase(isOpen ? null : phase.id)}
+                  aria-expanded={isOpen}
+                  className="grid w-full gap-2 py-3 text-left md:grid-cols-[1fr_auto_auto] hover:bg-ice-50"
+                >
+                  <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs text-navy/60">
+                        {phase.phase_sequence ?? "?"}.
+                      </span>
+                      <span className="font-semibold">{phase.phase_name}</span>
+                      <Badge
+                        tone={GATE_TONE[phase.gate_status ?? "pending"] ?? "neutral"}
+                      >
+                        {phase.gate_status ?? "pending"}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-navy/70">
+                      Planned {formatDate(phase.planned_start)} →{" "}
+                      {formatDate(phase.planned_end)}
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1">
+                    <span className="font-mono text-lg font-semibold text-navy">
+                      {(phase.percent_complete ?? 0).toFixed(0)}%
+                    </span>
+                    {varianceDays !== null ? (
+                      <span
+                        className={`text-xs ${varianceDays > 0 ? "text-danger-600" : "text-success-600"}`}
+                      >
+                        {varianceDays > 0 ? `+${varianceDays}d slip` : `${varianceDays}d ahead`}
+                      </span>
+                    ) : null}
+                  </div>
+                  <span className="self-center pr-1 text-navy/40">
+                    {isOpen ? (
+                      <ChevronUp className="size-4" aria-hidden="true" />
+                    ) : (
+                      <ChevronDown className="size-4" aria-hidden="true" />
+                    )}
+                  </span>
+                </button>
+                {isOpen ? (
+                  <dl className="grid grid-cols-2 gap-3 pb-3 pl-4 text-sm md:grid-cols-3">
+                    <DetailCell
+                      label="Actual"
+                      value={
+                        phase.actual_start
+                          ? `${formatDate(phase.actual_start)} → ${formatDate(phase.actual_end)}`
+                          : "pending"
+                      }
+                    />
+                    <DetailCell
+                      label="Gate approver"
+                      value={phase.gate_approver ?? "—"}
+                    />
+                    <DetailCell
+                      label="Gate date"
+                      value={formatDate(phase.gate_date)}
+                    />
+                    {phase.notes ? (
+                      <div className="md:col-span-3">
+                        <span className="kpi-label">Notes</span>
+                        <p className="text-sm italic text-navy/80">{phase.notes}</p>
+                      </div>
+                    ) : null}
+                  </dl>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="Milestones"
+          subtitle={`${milestones.data?.length ?? 0} tracked`}
+        />
+        <ol className="flex flex-col gap-2">
+          {(milestones.data ?? []).map((m) => {
+            const slipDays =
+              m.actual_date && m.planned_date
+                ? Math.round(
+                    (new Date(m.actual_date).getTime() -
+                      new Date(m.planned_date).getTime()) /
+                      (1000 * 60 * 60 * 24),
+                  )
+                : null;
+            const isOpen = expandedMilestone === m.id;
+            return (
+              <li
+                key={m.id}
+                className="rounded border border-ice-100 bg-white"
+              >
+                <button
+                  type="button"
+                  onClick={() => setExpandedMilestone(isOpen ? null : m.id)}
+                  aria-expanded={isOpen}
+                  className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition hover:bg-ice-50"
+                >
+                  <div>
+                    <p className="font-medium">{m.name}</p>
+                    <p className="text-xs text-navy/60">
+                      Planned {formatDate(m.planned_date)}
+                      {m.actual_date
+                        ? ` · Actual ${formatDate(m.actual_date)}`
+                        : ""}
+                      {m.owner ? ` · ${m.owner}` : ""}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge tone={STATUS_TONE[m.status] ?? "neutral"}>{m.status}</Badge>
+                    {slipDays !== null && slipDays !== 0 ? (
+                      <span
+                        className={`text-xs ${slipDays > 0 ? "text-danger-600" : "text-success-600"}`}
+                      >
+                        {slipDays > 0 ? `+${slipDays}d` : `${slipDays}d`}
+                      </span>
+                    ) : null}
+                    {isOpen ? (
+                      <ChevronUp className="size-4 text-navy/40" aria-hidden="true" />
+                    ) : (
+                      <ChevronDown className="size-4 text-navy/40" aria-hidden="true" />
+                    )}
+                  </div>
+                </button>
+                {isOpen ? (
+                  <dl className="grid grid-cols-2 gap-3 px-3 pb-3 text-sm md:grid-cols-3">
+                    <DetailCell label="Status" value={m.status} />
+                    <DetailCell label="Owner" value={m.owner ?? "—"} />
+                    <DetailCell
+                      label="Slip"
+                      value={
+                        slipDays === null
+                          ? "—"
+                          : slipDays > 0
+                            ? `+${slipDays}d`
+                            : `${slipDays}d`
+                      }
+                    />
+                    {m.notes ? (
+                      <div className="md:col-span-3">
+                        <span className="kpi-label">Notes</span>
+                        <p className="text-sm italic text-navy/80">{m.notes}</p>
+                      </div>
+                    ) : null}
+                  </dl>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+      </Card>
+    </div>
+  );
+}
+
+function DetailCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="kpi-label">{label}</span>
+      <span className="font-mono text-sm text-navy">{value}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Iteration 2b lands **Tab 3 Delivery Health** as a methodology-adaptive view (Scrum / Kanban / Waterfall) plus a full drill-down / drill-up / drill-across / drill-through navigation layer across every built tab.

## What's in

**Backend**
- 5 new read endpoints: `/api/v1/sprints`, `/evm`, `/flow`, `/phases`, `/milestones` (all filter by program_id/project_id).
- Delivery seed (`app/seed/delivery_data.py`): 18 Scrum sprints, 24 weekly flow rows, 6 Waterfall phases, 72 monthly EVM snapshots (CPI/SPI/EAC/TCPI/VAC computed at seed time), 26 milestones — shaped to the NovaTech narrative (Phoenix compressing, Sentinel lifting on AI, Orion bench-tax widening WIP, Titan mid-flight Waterfall).
- 5 new pytest cases (filters + ordering).

**Frontend — Tab 3 (`/delivery`)**
- Cross-programme project picker with methodology + AI badges.
- Common EVM strip (CPI/SPI/EAC/TCPI/%-Complete) with RAG tone + 12-month EVM trend chart.
- ScrumView: planned-vs-completed bars, velocity + rework/defects composed chart, dual-velocity chart on AI-augmented projects, expandable sprint ledger.
- KanbanView: stacked CFD via **ECharts** (`echarts-for-react`), p50/p85/p95 cycle-time percentile chart, WIP-breach badge.
- WaterfallView: phase timeline with gate status + slip days, milestone list.

**Drill navigation (all tabs)**
- Breadcrumb component: Portfolio › Tab › Programme › Project.
- **Drill-down**: Tab 1 RAG buckets → filter programmes; programme rows / Top Risks → `/delivery?programme=CODE`; KPI latest-values rows → `/delivery?programme=CODE`; sprint / phase / milestone rows → inline expand (leaf detail).
- **Drill-up**: breadcrumb links, clear-filter chips, re-click to collapse.
- **Drill-across**: Prev/Next project arrows in Delivery Health; KPI library sidebar in Studio.
- **Drill-through**: Tab 3 "View KPIs for PHOENIX" link; Tab 2 "View in Delivery Health" link from the filter chip.

## Quality gates
- pytest **28/28** pass · coverage above the 70% gate
- Vitest **17/17** pass
- ruff clean · ESLint clean · `tsc -b && vite build` green
- Docker compose smoke: backend healthy; all 5 delivery endpoints return expected row counts; nginx proxies resolve `/api/*` same-origin.

## Test plan
- [x] pytest (backend)
- [x] Vitest (frontend)
- [x] Docker compose build + up + endpoint smoke
- [x] Manual URL exercise (`/delivery?programme=PHOENIX` loads)
- [ ] Human visual QA of Tab 3 views + drill flow end-to-end

## Up next
I-2c: Tab 4 (Velocity & Flow) + Tab 5 (Margin & EVM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)