### PR TITLE
feat: Iteration 3a — Tab 6 Customer Intelligence

### DIFF
--- a/backend/app/api/v1/customer.py
+++ b/backend/app/api/v1/customer.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-from app.models import CustomerAction, CustomerExpectation, Program
-from app.schemas.customer import CustomerActionOut, CustomerExpectationOut
+from app.models import (
+    CustomerAction,
+    CustomerExpectation,
+    CustomerSatisfaction,
+    Program,
+    SlaIncident,
+)
+from app.schemas.customer import (
+    CustomerActionOut,
+    CustomerExpectationOut,
+    CustomerSatisfactionOut,
+    SlaIncidentOut,
+)
 
 router = APIRouter(prefix="/customer", tags=["customer"])
 
@@ -53,4 +64,39 @@ async def list_actions(
             CustomerAction.due_date.asc().nulls_last(),
         )
     )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@router.get(
+    "/satisfaction",
+    response_model=list[CustomerSatisfactionOut],
+    tags=["customer"],
+)
+async def list_satisfaction(
+    program_id: int | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[CustomerSatisfaction]:
+    stmt = select(CustomerSatisfaction)
+    if program_id is not None:
+        stmt = stmt.where(CustomerSatisfaction.program_id == program_id)
+    stmt = stmt.order_by(CustomerSatisfaction.snapshot_date.asc())
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@router.get(
+    "/sla-incidents",
+    response_model=list[SlaIncidentOut],
+    tags=["customer"],
+)
+async def list_sla_incidents(
+    program_id: int | None = Query(default=None),
+    breached_only: bool = Query(default=False),
+    session: AsyncSession = Depends(get_session),
+) -> list[SlaIncident]:
+    stmt = select(SlaIncident)
+    if program_id is not None:
+        stmt = stmt.where(SlaIncident.program_id == program_id)
+    if breached_only:
+        stmt = stmt.where(SlaIncident.sla_breached.is_(True))
+    stmt = stmt.order_by(SlaIncident.reported_at.desc())
     return list((await session.execute(stmt)).scalars().all())

--- a/backend/app/schemas/customer.py
+++ b/backend/app/schemas/customer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict
 
@@ -35,3 +35,43 @@ class CustomerActionOut(BaseModel):
     escalated: bool
     resolution_notes: str | None = None
     closed_date: date | None = None
+
+
+class CustomerSatisfactionOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    program_id: int | None = None
+    snapshot_date: date
+    csat_score: float | None = None
+    nps_score: float | None = None
+    escalation_count: int
+    escalation_open: int
+    steering_meetings_planned: int | None = None
+    steering_meetings_held: int | None = None
+    action_items_open: int | None = None
+    action_items_closed: int | None = None
+    positive_themes: str | None = None
+    concern_themes: str | None = None
+    renewal_score: float | None = None
+    notes: str | None = None
+
+
+class SlaIncidentOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    program_id: int | None = None
+    project_id: int | None = None
+    incident_id: str | None = None
+    priority: str
+    summary: str | None = None
+    reported_at: datetime
+    responded_at: datetime | None = None
+    resolved_at: datetime | None = None
+    response_time_minutes: float | None = None
+    resolution_time_minutes: float | None = None
+    sla_breached: bool
+    penalty_amount: float
+    root_cause: str | None = None
+    notes: str | None = None

--- a/backend/app/seed/customer_data.py
+++ b/backend/app/seed/customer_data.py
@@ -1,0 +1,279 @@
+"""Tab 6 Customer Intelligence demo data.
+
+Monthly customer_satisfaction snapshots (CSAT, NPS, steering meetings,
+action items) and the SLA-incident ledger that feeds the escalation log.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TypedDict
+
+
+class CustomerSatisfactionSeed(TypedDict):
+    program_code: str
+    snapshot_date: date
+    csat_score: float
+    nps_score: float
+    escalation_count: int
+    escalation_open: int
+    steering_meetings_planned: int
+    steering_meetings_held: int
+    action_items_open: int
+    action_items_closed: int
+    positive_themes: str
+    concern_themes: str
+    renewal_score: float | None
+    notes: str | None
+
+
+# 12 monthly rows per programme. Figures reflect the NovaTech narrative:
+# Phoenix + Orion + Titan drifting; Sentinel strongest; Atlas in between.
+def _cs_series(
+    program_code: str,
+    *,
+    csat: list[float],
+    nps: list[float],
+    escalations_total: list[int],
+    escalations_open: list[int],
+    meetings_planned: int,
+    meetings_held: list[int],
+    items_open: list[int],
+    items_closed: list[int],
+    positive_themes: str,
+    concern_themes: str,
+    renewal: list[float],
+) -> list[CustomerSatisfactionSeed]:
+    starts = [
+        date(2025, 4, 1), date(2025, 5, 1), date(2025, 6, 1), date(2025, 7, 1),
+        date(2025, 8, 1), date(2025, 9, 1), date(2025, 10, 1), date(2025, 11, 1),
+        date(2025, 12, 1), date(2026, 1, 1), date(2026, 2, 1), date(2026, 3, 1),
+    ]
+    return [
+        {
+            "program_code": program_code,
+            "snapshot_date": starts[i],
+            "csat_score": csat[i],
+            "nps_score": nps[i],
+            "escalation_count": escalations_total[i],
+            "escalation_open": escalations_open[i],
+            "steering_meetings_planned": meetings_planned,
+            "steering_meetings_held": meetings_held[i],
+            "action_items_open": items_open[i],
+            "action_items_closed": items_closed[i],
+            "positive_themes": positive_themes,
+            "concern_themes": concern_themes,
+            "renewal_score": renewal[i],
+            "notes": None,
+        }
+        for i in range(12)
+    ]
+
+
+CUSTOMER_SATISFACTION: list[CustomerSatisfactionSeed] = [
+    *_cs_series(
+        "PHOENIX",
+        csat=[8.2, 8.0, 7.9, 7.8, 7.6, 7.5, 7.3, 7.2, 7.0, 6.9, 6.8, 6.7],
+        nps=[45, 40, 38, 35, 30, 28, 24, 20, 16, 12, 8, 5],
+        escalations_total=[1, 2, 2, 3, 4, 4, 5, 6, 7, 8, 9, 10],
+        escalations_open=[0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5],
+        meetings_planned=2,
+        meetings_held=[2, 2, 2, 2, 2, 2, 1, 2, 1, 2, 2, 1],
+        items_open=[4, 5, 5, 6, 7, 8, 9, 10, 11, 11, 12, 13],
+        items_closed=[2, 3, 4, 4, 5, 5, 6, 6, 7, 8, 8, 9],
+        positive_themes="Domain depth; Responsive programme leadership",
+        concern_themes="CR margin erosion; Integration vendor slip; SLA pressure",
+        renewal=[82, 80, 77, 74, 70, 67, 62, 58, 54, 50, 46, 43],
+    ),
+    *_cs_series(
+        "ATLAS",
+        csat=[7.8, 7.8, 7.7, 7.7, 7.6, 7.6, 7.5, 7.4, 7.4, 7.3, 7.3, 7.2],
+        nps=[30, 30, 28, 28, 25, 25, 22, 20, 18, 16, 15, 13],
+        escalations_total=[0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4],
+        escalations_open=[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2],
+        meetings_planned=2,
+        meetings_held=[2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2],
+        items_open=[3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8],
+        items_closed=[1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7],
+        positive_themes="Cloud expertise; Migration pace",
+        concern_themes="Rate drift; Bench visibility",
+        renewal=[73, 72, 70, 69, 67, 65, 62, 60, 57, 54, 52, 50],
+    ),
+    *_cs_series(
+        "SENTINEL",
+        csat=[8.6, 8.7, 8.8, 8.8, 8.9, 9.0, 9.0, 9.1, 9.1, 9.2, 9.2, 9.3],
+        nps=[55, 58, 60, 62, 64, 65, 67, 68, 70, 72, 74, 75],
+        escalations_total=[0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+        escalations_open=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        meetings_planned=2,
+        meetings_held=[2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+        items_open=[2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 0, 0],
+        items_closed=[3, 4, 5, 5, 6, 6, 7, 7, 8, 9, 9, 10],
+        positive_themes="AI augmentation quality; Fast feedback loop; Transparent reporting",
+        concern_themes="None material",
+        renewal=[88, 89, 90, 91, 92, 92, 93, 93, 94, 94, 95, 95],
+    ),
+    *_cs_series(
+        "ORION",
+        csat=[7.9, 7.8, 7.5, 7.3, 7.0, 6.8, 6.5, 6.2, 6.0, 5.8, 5.5, 5.2],
+        nps=[25, 20, 15, 10, 5, 0, -5, -10, -15, -20, -25, -30],
+        escalations_total=[0, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11],
+        escalations_open=[0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 6],
+        meetings_planned=2,
+        meetings_held=[2, 2, 2, 2, 1, 2, 1, 1, 1, 2, 1, 1],
+        items_open=[5, 6, 7, 8, 10, 11, 13, 14, 15, 16, 18, 20],
+        items_closed=[2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8],
+        positive_themes="Strong data engineers",
+        concern_themes="Bench tax; Knowledge churn; Delivery slips",
+        renewal=[70, 66, 62, 57, 52, 47, 42, 37, 32, 28, 23, 20],
+    ),
+    *_cs_series(
+        "TITAN",
+        csat=[8.0, 7.9, 7.8, 7.5, 7.3, 7.0, 6.9, 6.8, 6.8, 6.8, 6.8, 6.8],
+        nps=[32, 30, 25, 20, 15, 10, 8, 6, 5, 5, 5, 5],
+        escalations_total=[0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+        escalations_open=[0, 0, 0, 0, 1, 0, 1, 1, 2, 1, 2, 2],
+        meetings_planned=2,
+        meetings_held=[2, 2, 2, 2, 1, 2, 2, 1, 2, 2, 2, 2],
+        items_open=[3, 3, 4, 5, 6, 6, 7, 7, 8, 8, 9, 9],
+        items_closed=[1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7],
+        positive_themes="Front-end velocity; UX polish",
+        concern_themes="SLA breaches; Attrition impact",
+        renewal=[75, 73, 70, 65, 60, 56, 54, 52, 50, 50, 50, 50],
+    ),
+]
+
+
+class SlaIncidentSeed(TypedDict):
+    program_code: str
+    incident_id: str
+    priority: str
+    summary: str
+    reported_at: datetime
+    responded_at: datetime | None
+    resolved_at: datetime | None
+    response_time_minutes: float | None
+    resolution_time_minutes: float | None
+    sla_breached: bool
+    penalty_amount: float
+    root_cause: str | None
+
+
+SLA_INCIDENTS: list[SlaIncidentSeed] = [
+    # Titan P1 breaches (matching the narrative)
+    {
+        "program_code": "TITAN",
+        "incident_id": "INC-2026-0412",
+        "priority": "P1",
+        "summary": "Checkout service 5xx surge",
+        "reported_at": datetime(2026, 1, 18, 11, 45),
+        "responded_at": datetime(2026, 1, 18, 12, 40),
+        "resolved_at": datetime(2026, 1, 19, 9, 20),
+        "response_time_minutes": 55.0,
+        "resolution_time_minutes": 21 * 60 + 35,
+        "sla_breached": True,
+        "penalty_amount": 150_000,
+        "root_cause": "Cache stampede during peak traffic",
+    },
+    {
+        "program_code": "TITAN",
+        "incident_id": "INC-2026-0587",
+        "priority": "P1",
+        "summary": "Payment gateway timeout",
+        "reported_at": datetime(2026, 3, 4, 18, 22),
+        "responded_at": datetime(2026, 3, 4, 19, 50),
+        "resolved_at": datetime(2026, 3, 5, 4, 10),
+        "response_time_minutes": 88.0,
+        "resolution_time_minutes": 9 * 60 + 48,
+        "sla_breached": True,
+        "penalty_amount": 250_000,
+        "root_cause": "Third-party gateway region outage; runbook missing failover step",
+    },
+    {
+        "program_code": "TITAN",
+        "incident_id": "INC-2026-0612",
+        "priority": "P2",
+        "summary": "Product search slow",
+        "reported_at": datetime(2026, 3, 15, 10, 0),
+        "responded_at": datetime(2026, 3, 15, 10, 35),
+        "resolved_at": datetime(2026, 3, 15, 15, 10),
+        "response_time_minutes": 35.0,
+        "resolution_time_minutes": 5 * 60 + 10,
+        "sla_breached": False,
+        "penalty_amount": 0,
+        "root_cause": "Elasticsearch index hotspot",
+    },
+    # Phoenix SLA breach
+    {
+        "program_code": "PHOENIX",
+        "incident_id": "INC-2026-0104",
+        "priority": "P2",
+        "summary": "Core module batch job overran",
+        "reported_at": datetime(2026, 2, 2, 2, 30),
+        "responded_at": datetime(2026, 2, 2, 3, 15),
+        "resolved_at": datetime(2026, 2, 2, 9, 45),
+        "response_time_minutes": 45.0,
+        "resolution_time_minutes": 7 * 60 + 15,
+        "sla_breached": True,
+        "penalty_amount": 40_000,
+        "root_cause": "Scope CR increased batch window",
+    },
+    # Orion incidents
+    {
+        "program_code": "ORION",
+        "incident_id": "INC-2026-0231",
+        "priority": "P2",
+        "summary": "Analytics mart refresh failed",
+        "reported_at": datetime(2026, 2, 14, 6, 0),
+        "responded_at": datetime(2026, 2, 14, 7, 40),
+        "resolved_at": datetime(2026, 2, 14, 15, 0),
+        "response_time_minutes": 100.0,
+        "resolution_time_minutes": 9 * 60,
+        "sla_breached": True,
+        "penalty_amount": 60_000,
+        "root_cause": "Bench rotation; on-call unfamiliar with pipeline",
+    },
+    {
+        "program_code": "ORION",
+        "incident_id": "INC-2026-0398",
+        "priority": "P3",
+        "summary": "Ingest job latency spike",
+        "reported_at": datetime(2026, 3, 2, 14, 0),
+        "responded_at": datetime(2026, 3, 2, 14, 55),
+        "resolved_at": datetime(2026, 3, 2, 17, 30),
+        "response_time_minutes": 55.0,
+        "resolution_time_minutes": 3 * 60 + 30,
+        "sla_breached": False,
+        "penalty_amount": 0,
+        "root_cause": "Upstream source throttling",
+    },
+    # Atlas incident
+    {
+        "program_code": "ATLAS",
+        "incident_id": "INC-2026-0450",
+        "priority": "P3",
+        "summary": "Terraform plan drift",
+        "reported_at": datetime(2026, 3, 10, 9, 30),
+        "responded_at": datetime(2026, 3, 10, 10, 10),
+        "resolved_at": datetime(2026, 3, 10, 11, 50),
+        "response_time_minutes": 40.0,
+        "resolution_time_minutes": 2 * 60 + 20,
+        "sla_breached": False,
+        "penalty_amount": 0,
+        "root_cause": "Manual console change",
+    },
+    # Sentinel — one benign P3 to show responsiveness
+    {
+        "program_code": "SENTINEL",
+        "incident_id": "INC-2026-0511",
+        "priority": "P3",
+        "summary": "Test env flaky",
+        "reported_at": datetime(2026, 3, 18, 12, 0),
+        "responded_at": datetime(2026, 3, 18, 12, 20),
+        "resolved_at": datetime(2026, 3, 18, 13, 5),
+        "response_time_minutes": 20.0,
+        "resolution_time_minutes": 65.0,
+        "sla_breached": False,
+        "penalty_amount": 0,
+        "root_cause": "Dependency version mismatch",
+    },
+]

--- a/backend/app/seed/seeder.py
+++ b/backend/app/seed/seeder.py
@@ -12,6 +12,7 @@ from app.models import (
     CurrencyRate,
     CustomerAction,
     CustomerExpectation,
+    CustomerSatisfaction,
     EvmSnapshot,
     FlowMetrics,
     KpiDefinition,
@@ -24,6 +25,7 @@ from app.models import (
     RateCard,
     Risk,
     ScopeCreepLog,
+    SlaIncident,
     SprintData,
     SprintVelocityBlendRule,
     SprintVelocityDual,
@@ -36,6 +38,7 @@ from app.seed.commercial_data import (
     RATE_CARDS,
     SPRINT_VELOCITY_DUAL,
 )
+from app.seed.customer_data import CUSTOMER_SATISFACTION, SLA_INCIDENTS
 from app.seed.data import (
     APP_SETTINGS_DEFAULTS,
     CURRENCY_RATES,
@@ -90,6 +93,8 @@ async def seed_demo_data(session: AsyncSession, *, force: bool = False) -> bool:
     await _seed_loss_exposure(session, program_ids)
     await _seed_rate_cards(session, program_ids)
     await _seed_change_requests(session, program_ids, project_ids)
+    await _seed_customer_satisfaction(session, program_ids)
+    await _seed_sla_incidents(session, program_ids)
 
     await session.commit()
     log.info(
@@ -111,6 +116,8 @@ async def seed_demo_data(session: AsyncSession, *, force: bool = False) -> bool:
         losses=len(LOSS_EXPOSURE),
         rate_cards=len(RATE_CARDS),
         change_requests=len(CHANGE_REQUESTS),
+        customer_satisfaction=len(CUSTOMER_SATISFACTION),
+        sla_incidents=len(SLA_INCIDENTS),
     )
     return True
 
@@ -434,3 +441,27 @@ async def _seed_change_requests(
         session.add(
             ScopeCreepLog(program_id=program_id, project_id=project_id, **payload)
         )
+
+
+async def _seed_customer_satisfaction(
+    session: AsyncSession,
+    program_ids: dict[str, int],
+) -> None:
+    for data in CUSTOMER_SATISFACTION:
+        payload = dict(data)
+        program_id = program_ids.get(payload.pop("program_code"))
+        if program_id is None:
+            continue
+        session.add(CustomerSatisfaction(program_id=program_id, **payload))
+
+
+async def _seed_sla_incidents(
+    session: AsyncSession,
+    program_ids: dict[str, int],
+) -> None:
+    for data in SLA_INCIDENTS:
+        payload = dict(data)
+        program_id = program_ids.get(payload.pop("program_code"))
+        if program_id is None:
+            continue
+        session.add(SlaIncident(program_id=program_id, **payload))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Layout } from "@/components/Layout";
 import { queryClient } from "@/lib/queryClient";
+import { CustomerIntelligence } from "@/pages/CustomerIntelligence";
 import { ExecutiveOverview } from "@/pages/ExecutiveOverview";
 import { DataHub } from "@/pages/DataHub";
 import { DeliveryHealth } from "@/pages/DeliveryHealth";
@@ -20,6 +21,7 @@ const router = createBrowserRouter([
       { path: "delivery", element: <DeliveryHealth /> },
       { path: "velocity", element: <VelocityFlow /> },
       { path: "margin", element: <MarginEvm /> },
+      { path: "customer", element: <CustomerIntelligence /> },
       { path: "data-hub", element: <DataHub /> },
       { path: "*", element: <NotFound /> },
     ],

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,7 +9,7 @@ const tabs = [
   { to: "/delivery", label: "Delivery", num: "03" },
   { to: "/velocity", label: "Velocity & Flow", num: "04" },
   { to: "/margin", label: "Margin & EVM", num: "05" },
-  { to: "/customer", label: "Customer", num: "06", disabled: true },
+  { to: "/customer", label: "Customer", num: "06" },
   { to: "/ai", label: "AI Governance", num: "07", disabled: true },
   { to: "/smart-ops", label: "Smart Ops", num: "08", disabled: true },
   { to: "/raid", label: "Risk & Audit", num: "09", disabled: true },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -423,6 +423,113 @@ export async function fetchChangeRequests(programId?: number): Promise<ChangeReq
   return data;
 }
 
+// ---------- Customer Intelligence ----------
+
+export type CustomerSatisfaction = {
+  id: number;
+  program_id: number | null;
+  snapshot_date: string;
+  csat_score: number | null;
+  nps_score: number | null;
+  escalation_count: number;
+  escalation_open: number;
+  steering_meetings_planned: number | null;
+  steering_meetings_held: number | null;
+  action_items_open: number | null;
+  action_items_closed: number | null;
+  positive_themes: string | null;
+  concern_themes: string | null;
+  renewal_score: number | null;
+};
+
+export type SlaIncident = {
+  id: number;
+  program_id: number | null;
+  incident_id: string | null;
+  priority: string;
+  summary: string | null;
+  reported_at: string;
+  responded_at: string | null;
+  resolved_at: string | null;
+  response_time_minutes: number | null;
+  resolution_time_minutes: number | null;
+  sla_breached: boolean;
+  penalty_amount: number;
+  root_cause: string | null;
+};
+
+export type CustomerExpectation = {
+  id: number;
+  program_id: number | null;
+  snapshot_date: string;
+  dimension: string;
+  expected_score: number | null;
+  delivered_score: number | null;
+  gap: number | null;
+  weight: number;
+  evidence_source: string | null;
+  owner: string | null;
+  notes: string | null;
+};
+
+export type CustomerAction = {
+  id: number;
+  program_id: number | null;
+  meeting_date: string | null;
+  description: string;
+  owner: string | null;
+  due_date: string | null;
+  status: string;
+  priority: string | null;
+  escalated: boolean;
+  resolution_notes: string | null;
+  closed_date: string | null;
+};
+
+export async function fetchCustomerSatisfaction(
+  programId?: number,
+): Promise<CustomerSatisfaction[]> {
+  const { data } = await api.get<CustomerSatisfaction[]>(
+    "/api/v1/customer/satisfaction",
+    { params: programId ? { program_id: programId } : undefined },
+  );
+  return data;
+}
+
+export async function fetchSlaIncidents(
+  programId?: number,
+  breachedOnly = false,
+): Promise<SlaIncident[]> {
+  const { data } = await api.get<SlaIncident[]>(
+    "/api/v1/customer/sla-incidents",
+    {
+      params: {
+        program_id: programId,
+        breached_only: breachedOnly || undefined,
+      },
+    },
+  );
+  return data;
+}
+
+export async function fetchCustomerExpectations(
+  programId: number,
+): Promise<CustomerExpectation[]> {
+  const { data } = await api.get<CustomerExpectation[]>(
+    `/api/v1/customer/${programId}/expectations`,
+  );
+  return data;
+}
+
+export async function fetchCustomerActions(
+  programId: number,
+): Promise<CustomerAction[]> {
+  const { data } = await api.get<CustomerAction[]>(
+    `/api/v1/customer/${programId}/actions`,
+  );
+  return data;
+}
+
 export async function previewCsv(file: File): Promise<{
   filename: string;
   columns: string[];

--- a/frontend/src/pages/CustomerIntelligence.tsx
+++ b/frontend/src/pages/CustomerIntelligence.tsx
@@ -1,0 +1,569 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { AlertOctagon, ChevronRight, Home, Sparkles, X } from "lucide-react";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import {
+  fetchCustomerActions,
+  fetchCustomerExpectations,
+  fetchCustomerSatisfaction,
+  fetchSlaIncidents,
+  type CustomerSatisfaction,
+} from "@/lib/api";
+import { useProgrammes } from "@/hooks/usePortfolio";
+import { useCurrency } from "@/hooks/useCurrency";
+import { formatDate, type RagBucket } from "@/lib/format";
+
+function renewalTone(score: number | null): RagBucket {
+  if (score === null) return "amber";
+  if (score >= 80) return "green";
+  if (score >= 60) return "amber";
+  return "red";
+}
+
+function csatTone(score: number | null): RagBucket {
+  if (score === null) return "amber";
+  if (score >= 8) return "green";
+  if (score >= 7) return "amber";
+  return "red";
+}
+
+function npsTone(score: number | null): RagBucket {
+  if (score === null) return "amber";
+  if (score >= 30) return "green";
+  if (score >= 0) return "amber";
+  return "red";
+}
+
+export function CustomerIntelligence() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const programmeFilter = searchParams.get("programme");
+  const programmes = useProgrammes();
+  const currency = useCurrency();
+
+  const [activeProgrammeId, setActiveProgrammeId] = useState<number | null>(null);
+
+  const filteredProgramme = useMemo(
+    () => programmes.data?.find((p) => p.code === programmeFilter) ?? null,
+    [programmes.data, programmeFilter],
+  );
+
+  // Default to the programme from the URL filter, else the first programme.
+  useEffect(() => {
+    if (filteredProgramme) {
+      setActiveProgrammeId(filteredProgramme.id);
+    } else if (!activeProgrammeId && programmes.data && programmes.data.length > 0) {
+      setActiveProgrammeId(programmes.data[0].id);
+    }
+  }, [filteredProgramme, programmes.data, activeProgrammeId]);
+
+  const activeProgramme = useMemo(
+    () => programmes.data?.find((p) => p.id === activeProgrammeId) ?? null,
+    [programmes.data, activeProgrammeId],
+  );
+
+  const satisfaction = useQuery({
+    queryKey: ["satisfaction", activeProgrammeId],
+    queryFn: () =>
+      activeProgrammeId
+        ? fetchCustomerSatisfaction(activeProgrammeId)
+        : Promise.resolve([] as CustomerSatisfaction[]),
+    enabled: activeProgrammeId !== null,
+  });
+  const expectations = useQuery({
+    queryKey: ["expectations", activeProgrammeId],
+    queryFn: () =>
+      activeProgrammeId
+        ? fetchCustomerExpectations(activeProgrammeId)
+        : Promise.resolve([]),
+    enabled: activeProgrammeId !== null,
+  });
+  const actions = useQuery({
+    queryKey: ["actions", activeProgrammeId],
+    queryFn: () =>
+      activeProgrammeId
+        ? fetchCustomerActions(activeProgrammeId)
+        : Promise.resolve([]),
+    enabled: activeProgrammeId !== null,
+  });
+  const incidents = useQuery({
+    queryKey: ["sla-incidents", activeProgrammeId],
+    queryFn: () =>
+      activeProgrammeId
+        ? fetchSlaIncidents(activeProgrammeId)
+        : Promise.resolve([]),
+    enabled: activeProgrammeId !== null,
+  });
+
+  const clearProgrammeFilter = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("programme");
+    setSearchParams(next);
+  };
+
+  const latest = useMemo(() => {
+    const rows = satisfaction.data ?? [];
+    return rows.length > 0 ? rows[rows.length - 1] : null;
+  }, [satisfaction.data]);
+
+  const trendData = useMemo(() => {
+    return (satisfaction.data ?? []).map((r) => ({
+      month: r.snapshot_date.slice(0, 7),
+      monthLabel: monthLabel(r.snapshot_date),
+      csat: r.csat_score,
+      nps: r.nps_score,
+      renewal: r.renewal_score,
+    }));
+  }, [satisfaction.data]);
+
+  const radarData = useMemo(() => {
+    // Aggregate by dimension (pick latest snapshot per dimension).
+    const byDim = new Map<string, { expected: number; delivered: number }>();
+    for (const row of expectations.data ?? []) {
+      byDim.set(row.dimension, {
+        expected: row.expected_score ?? 0,
+        delivered: row.delivered_score ?? 0,
+      });
+    }
+    const allDims = [
+      "timeline",
+      "quality",
+      "communication",
+      "innovation",
+      "cost",
+      "responsiveness",
+      "stability",
+    ];
+    return allDims.map((dim) => {
+      const row = byDim.get(dim);
+      return {
+        dimension: dim,
+        expected: row?.expected ?? 0,
+        delivered: row?.delivered ?? 0,
+      };
+    });
+  }, [expectations.data]);
+
+  const breadcrumbItems = [
+    { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
+    { label: "Customer Intelligence", to: filteredProgramme ? "/customer" : undefined },
+    ...(activeProgramme ? [{ label: activeProgramme.name }] : []),
+  ];
+
+  const sourceCurrency = activeProgramme?.currency_code ?? "INR";
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Breadcrumb items={breadcrumbItems} />
+
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-navy">Customer Intelligence</h1>
+          <p className="mt-1 text-sm text-navy/70">
+            Will this customer renew? Where is their expectation gap widest?
+            What escalations are open?
+          </p>
+        </div>
+        {activeProgramme ? (
+          <Link
+            to={`/delivery?programme=${activeProgramme.code}`}
+            className="btn-ghost"
+          >
+            View Delivery Health <ChevronRight className="size-3" />
+          </Link>
+        ) : null}
+      </div>
+
+      {filteredProgramme ? (
+        <div className="inline-flex items-center gap-2 self-start rounded-full border border-navy/30 bg-navy/5 px-3 py-1 text-xs text-navy">
+          Filtered to <strong>{filteredProgramme.name}</strong>
+          <button
+            type="button"
+            onClick={clearProgrammeFilter}
+            className="inline-flex items-center rounded-full bg-navy/10 px-1.5 py-0.5 transition hover:bg-navy/20"
+            aria-label="Clear programme filter (drill up)"
+          >
+            <X className="size-3" /> clear
+          </button>
+        </div>
+      ) : null}
+
+      {!filteredProgramme ? (
+        <Card>
+          <CardHeader title="Pick a programme" subtitle="Customer intelligence is per-programme" />
+          <div className="flex flex-wrap gap-2">
+            {(programmes.data ?? []).map((p) => {
+              const isActive = p.id === activeProgrammeId;
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setActiveProgrammeId(p.id)}
+                  className={`rounded-md border px-3 py-2 text-sm transition ${
+                    isActive
+                      ? "border-navy bg-navy text-white"
+                      : "border-ice-100 bg-white text-navy hover:bg-ice-50"
+                  }`}
+                >
+                  {p.code}
+                </button>
+              );
+            })}
+          </div>
+        </Card>
+      ) : null}
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <Stat
+          label="CSAT"
+          value={latest?.csat_score != null ? latest.csat_score.toFixed(1) : "—"}
+          tone={csatTone(latest?.csat_score ?? null)}
+          sub="0-10"
+        />
+        <Stat
+          label="NPS"
+          value={latest?.nps_score != null ? latest.nps_score.toFixed(0) : "—"}
+          tone={npsTone(latest?.nps_score ?? null)}
+        />
+        <Stat
+          label="Open escalations"
+          value={`${latest?.escalation_open ?? 0}`}
+          tone={(latest?.escalation_open ?? 0) === 0 ? "green" : (latest?.escalation_open ?? 0) > 3 ? "red" : "amber"}
+          sub={`total ${latest?.escalation_count ?? 0}`}
+        />
+        <Stat
+          label="Renewal probability"
+          value={latest?.renewal_score != null ? `${latest.renewal_score.toFixed(0)}%` : "—"}
+          tone={renewalTone(latest?.renewal_score ?? null)}
+        />
+      </section>
+
+      <Card>
+        <CardHeader
+          title="CSAT / NPS / Renewal trend"
+          subtitle="12-month moving picture"
+        />
+        <div className="h-72">
+          {trendData.length === 0 ? (
+            <p className="grid h-full place-items-center text-sm text-navy/60">
+              No customer-satisfaction rows yet.
+            </p>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={trendData} margin={{ top: 8, right: 24, left: 0, bottom: 8 }}>
+                <CartesianGrid stroke="#E4EEF4" strokeDasharray="4 4" />
+                <XAxis dataKey="monthLabel" stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+                <YAxis
+                  yAxisId="left"
+                  stroke="#1B2A4A"
+                  tick={{ fontSize: 12 }}
+                  domain={[0, 100]}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  stroke="#1B2A4A"
+                  tick={{ fontSize: 12 }}
+                  domain={[-100, 100]}
+                />
+                <Tooltip contentStyle={{ border: "1px solid #D5E8F0" }} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="csat"
+                  name="CSAT (scaled ×10)"
+                  stroke="#10B981"
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="nps"
+                  name="NPS"
+                  stroke="#1B2A4A"
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="renewal"
+                  name="Renewal %"
+                  stroke="#F59E0B"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </Card>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader
+            title="Expectation gap — 7 dimensions"
+            subtitle="Expected vs delivered score per ARCHITECTURE.md §4.10"
+          />
+          <div className="h-80">
+            {radarData.every((r) => r.expected === 0 && r.delivered === 0) ? (
+              <p className="grid h-full place-items-center text-sm text-navy/60">
+                No expectation rows seeded for this programme.
+              </p>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <RadarChart data={radarData}>
+                  <PolarGrid stroke="#D5E8F0" />
+                  <PolarAngleAxis dataKey="dimension" tick={{ fontSize: 11 }} />
+                  <PolarRadiusAxis domain={[0, 10]} tick={{ fontSize: 10 }} />
+                  <Radar
+                    name="Expected"
+                    dataKey="expected"
+                    stroke="#1B2A4A"
+                    fill="#1B2A4A"
+                    fillOpacity={0.1}
+                  />
+                  <Radar
+                    name="Delivered"
+                    dataKey="delivered"
+                    stroke="#F59E0B"
+                    fill="#F59E0B"
+                    fillOpacity={0.25}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
+                  <Tooltip contentStyle={{ border: "1px solid #D5E8F0" }} />
+                </RadarChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </Card>
+
+        <Card>
+          <CardHeader
+            title="Communication tracker"
+            subtitle="Steering cadence + action items"
+          />
+          {latest ? (
+            <>
+              <dl className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                <Tile
+                  label="Meetings (this month)"
+                  value={`${latest.steering_meetings_held ?? 0} / ${latest.steering_meetings_planned ?? 0}`}
+                />
+                <Tile
+                  label="Action items open"
+                  value={`${latest.action_items_open ?? 0}`}
+                />
+                <Tile
+                  label="Closed"
+                  value={`${latest.action_items_closed ?? 0}`}
+                />
+                <Tile
+                  label="Escalations open"
+                  value={`${latest.escalation_open}`}
+                />
+              </dl>
+              <div className="mt-4 flex flex-col gap-2 text-sm">
+                <p>
+                  <span className="kpi-label">Positive themes</span>
+                  <br />
+                  {latest.positive_themes ?? "—"}
+                </p>
+                <p>
+                  <span className="kpi-label">Concern themes</span>
+                  <br />
+                  <span className="text-danger-600">
+                    {latest.concern_themes ?? "—"}
+                  </span>
+                </p>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-navy/60">No communication data yet.</p>
+          )}
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Action items"
+          subtitle={`${actions.data?.length ?? 0} tracked`}
+          action={<Sparkles className="size-4 text-amber-500" aria-hidden="true" />}
+        />
+        {(actions.data ?? []).length === 0 ? (
+          <p className="text-sm text-navy/60">No steering-committee actions recorded.</p>
+        ) : (
+          <ul className="flex flex-col gap-2 text-sm">
+            {(actions.data ?? []).map((a) => (
+              <li
+                key={a.id}
+                className="flex items-center justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2"
+              >
+                <div>
+                  <p className="font-medium">{a.description}</p>
+                  <p className="text-xs text-navy/60">
+                    Meeting {formatDate(a.meeting_date)}
+                    {a.owner ? ` · ${a.owner}` : ""}
+                    {a.due_date ? ` · due ${formatDate(a.due_date)}` : ""}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {a.escalated ? (
+                    <Badge tone="red">
+                      <AlertOctagon className="size-3" /> escalated
+                    </Badge>
+                  ) : null}
+                  <Badge tone={a.priority === "P1" ? "red" : a.priority === "P2" ? "amber" : "neutral"}>
+                    {a.priority ?? "—"}
+                  </Badge>
+                  <Badge
+                    tone={
+                      a.status === "Closed"
+                        ? "green"
+                        : a.status === "Open"
+                          ? "amber"
+                          : "neutral"
+                    }
+                  >
+                    {a.status}
+                  </Badge>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="SLA incident ledger"
+          subtitle="Breaches incur penalty amounts — shown in the active base currency"
+        />
+        {(incidents.data ?? []).length === 0 ? (
+          <p className="text-sm text-navy/60">
+            No SLA incidents recorded for this programme.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase text-navy/60">
+                  <th className="py-2">ID</th>
+                  <th>Priority</th>
+                  <th>Summary</th>
+                  <th className="text-right">Response</th>
+                  <th className="text-right">Resolution</th>
+                  <th className="text-right">Penalty</th>
+                  <th className="text-right">Breach?</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(incidents.data ?? []).map((i) => (
+                  <tr key={i.id} className="border-t border-ice-100">
+                    <td className="py-2 font-mono text-xs">{i.incident_id ?? "—"}</td>
+                    <td>
+                      <Badge
+                        tone={
+                          i.priority === "P1"
+                            ? "red"
+                            : i.priority === "P2"
+                              ? "amber"
+                              : "neutral"
+                        }
+                      >
+                        {i.priority}
+                      </Badge>
+                    </td>
+                    <td>
+                      <p className="font-medium">{i.summary ?? "—"}</p>
+                      {i.root_cause ? (
+                        <p className="text-xs text-navy/60">{i.root_cause}</p>
+                      ) : null}
+                    </td>
+                    <td className="text-right font-mono">
+                      {i.response_time_minutes === null
+                        ? "—"
+                        : `${i.response_time_minutes.toFixed(0)}m`}
+                    </td>
+                    <td className="text-right font-mono">
+                      {i.resolution_time_minutes === null
+                        ? "—"
+                        : `${(i.resolution_time_minutes / 60).toFixed(1)}h`}
+                    </td>
+                    <td className="text-right font-mono">
+                      {currency.format(i.penalty_amount, sourceCurrency)}
+                    </td>
+                    <td className="text-right">
+                      {i.sla_breached ? (
+                        <Badge tone="red">breach</Badge>
+                      ) : (
+                        <Badge tone="green">met</Badge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: "green" | "amber" | "red" | "neutral";
+}) {
+  return (
+    <div className="rounded border border-ice-100 bg-white px-3 py-2">
+      <span className="kpi-label">{label}</span>
+      <div className="flex items-center gap-2">
+        <p className="font-mono text-xl font-semibold text-navy">{value}</p>
+        {tone !== "neutral" ? <Badge tone={tone}>·</Badge> : null}
+      </div>
+      {sub ? <p className="text-xs text-navy/60">{sub}</p> : null}
+    </div>
+  );
+}
+
+function Tile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="kpi-label">{label}</span>
+      <span className="font-mono text-lg font-semibold text-navy">{value}</span>
+    </div>
+  );
+}
+
+function monthLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-GB", { month: "short", year: "2-digit" });
+}


### PR DESCRIPTION
## Summary
First slice of Iteration 3. Ships **Tab 6 Customer Intelligence** end-to-end.

## What's in

**Backend**
- Seed: 60 customer_satisfaction rows (5 programmes × 12 months) + 8 SLA incidents (4 breaches).
- 2 new endpoints: `GET /api/v1/customer/satisfaction`, `GET /api/v1/customer/sla-incidents` (with `breached_only` filter).

**Frontend — Tab 6 (`/customer`)**
- Programme picker (auto-selects from `?programme=CODE`).
- KPI tiles: CSAT / NPS / Open escalations / Renewal probability (tone-mapped from docs thresholds).
- 12-month dual-axis trend chart (CSAT + NPS + Renewal).
- **7-dimension Expectation Gap radar chart** — reuses `customer_expectations` from Iteration 1.
- Communication tracker: steering meetings held vs planned, action items open/closed, Voice-of-Customer themes.
- Action items list with Escalated / Priority / Status badges.
- SLA incident ledger with response / resolution times and currency-aware penalty amounts.
- Breadcrumb + clear-filter chip + drill-through to Delivery Health.

## Quality gates
- pytest **33/33** · ruff + ESLint clean · build green
- Docker smoke: satisfaction=60 rows · sla_breaches=4

## Up next
- I-3b: Tab 7 AI Governance (6-factor trust composite, override log, productivity tax)
- I-3c: Tab 8 Smart Ops + Tab 9 Risk & Audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)