### PR TITLE
feat: Iteration 3c — Tab 8 Smart Ops + Tab 9 Risk & Audit

### DIFF
--- a/backend/app/api/v1/ops.py
+++ b/backend/app/api/v1/ops.py
@@ -1,0 +1,51 @@
+"""Tab 8 Smart Ops + Tab 9 Risk & Audit endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.models import AuditLog, ResourcePool, ScenarioExecution
+from app.schemas.ops import AuditLogOut, ResourcePoolOut, ScenarioExecutionOut
+
+scenarios_router = APIRouter(prefix="/smart-ops/scenarios", tags=["ops"])
+resources_router = APIRouter(prefix="/smart-ops/resources", tags=["ops"])
+audit_router = APIRouter(prefix="/audit", tags=["audit"])
+
+
+@scenarios_router.get("", response_model=list[ScenarioExecutionOut])
+async def list_scenarios(
+    status: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[ScenarioExecution]:
+    stmt = select(ScenarioExecution)
+    if status is not None:
+        stmt = stmt.where(ScenarioExecution.status == status)
+    stmt = stmt.order_by(ScenarioExecution.execution_date.desc())
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@resources_router.get("", response_model=list[ResourcePoolOut])
+async def list_resources(
+    bench_only: bool = Query(default=False),
+    session: AsyncSession = Depends(get_session),
+) -> list[ResourcePool]:
+    stmt = select(ResourcePool)
+    if bench_only:
+        stmt = stmt.where(ResourcePool.status == "Bench")
+    stmt = stmt.order_by(ResourcePool.bench_days.desc(), ResourcePool.name)
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@audit_router.get("", response_model=list[AuditLogOut])
+async def list_audit(
+    table_name: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    session: AsyncSession = Depends(get_session),
+) -> list[AuditLog]:
+    stmt = select(AuditLog)
+    if table_name is not None:
+        stmt = stmt.where(AuditLog.table_name == table_name)
+    stmt = stmt.order_by(AuditLog.timestamp.desc()).limit(limit)
+    return list((await session.execute(stmt)).scalars().all())

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -11,6 +11,7 @@ from app.api.v1 import (
     delivery,
     health,
     kpi,
+    ops,
     programmes,
     risks,
     settings,
@@ -42,5 +43,8 @@ api_router.include_router(ai.sdlc_metrics_router)
 api_router.include_router(ai.trust_router)
 api_router.include_router(ai.governance_router)
 api_router.include_router(ai.override_router)
+api_router.include_router(ops.scenarios_router)
+api_router.include_router(ops.resources_router)
+api_router.include_router(ops.audit_router)
 api_router.include_router(settings.router)
 api_router.include_router(data_import.router)

--- a/backend/app/schemas/ops.py
+++ b/backend/app/schemas/ops.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ScenarioExecutionOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    scenario_name: str
+    execution_date: datetime | None = None
+    triggered_by: str | None = None
+    status: str | None = None
+    details: str | None = None
+    financial_impact: float | None = None
+    outcome_notes: str | None = None
+
+
+class ResourcePoolOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    role: str | None = None
+    role_tier: str | None = None
+    skill_set: str | None = None
+    current_program_id: int | None = None
+    current_project_id: int | None = None
+    utilization_pct: float | None = None
+    bench_days: int
+    loaded_cost_annual: float | None = None
+    status: str
+
+
+class AuditLogOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    action: str | None = None
+    table_name: str | None = None
+    record_id: int | None = None
+    old_value: str | None = None
+    new_value: str | None = None
+    user_action: str | None = None
+    timestamp: datetime

--- a/backend/app/seed/ops_data.py
+++ b/backend/app/seed/ops_data.py
@@ -1,0 +1,152 @@
+"""Tab 8 (Smart Ops) + Tab 9 (Risk & Audit) demo data.
+
+Smart Ops: the 8 proactive-detection scenarios from ARCHITECTURE.md §11
+(each scenario execution = one triggered alert). Resource pool provides
+the bench ledger used by the Smart Ops narrative.
+
+Risk & Audit: audit_log entries show representative admin and data
+changes across the portfolio.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TypedDict
+
+
+class ScenarioExecutionSeed(TypedDict):
+    scenario_name: str
+    execution_date: datetime
+    triggered_by: str
+    status: str
+    details: str
+    financial_impact: float
+    outcome_notes: str | None
+
+
+# ARCHITECTURE.md §11 Smart Ops scenarios:
+# 1 Bench Tax rising, 2 Margin Cliff projected, 3 Scope Creep unbilled,
+# 4 Rate Card Drift, 5 Attrition Wave, 6 SLA Breach pattern, 7 Customer
+# Satisfaction Drift, 8 AI Trust Regression.
+SCENARIO_EXECUTIONS: list[ScenarioExecutionSeed] = [
+    {
+        "scenario_name": "Bench Tax Rising",
+        "execution_date": datetime(2026, 3, 31, 9, 15),
+        "triggered_by": "Monthly batch",
+        "status": "Active",
+        "details": '{"program":"ORION","bench_fte":12,"shadow_cost":765000,"trend":"up"}',
+        "financial_impact": 765_000,
+        "outcome_notes": "Redeploy plan drafted; 4 FTE to Atlas in Q2",
+    },
+    {
+        "scenario_name": "Margin Cliff Projected",
+        "execution_date": datetime(2026, 3, 29, 11, 30),
+        "triggered_by": "Forecast pipeline",
+        "status": "Active",
+        "details": '{"program":"ATLAS","breakeven_month":8,"confidence":0.78}',
+        "financial_impact": 600_000,
+        "outcome_notes": "CAB reviewing team mix rebalance",
+    },
+    {
+        "scenario_name": "Scope Creep Unbilled",
+        "execution_date": datetime(2026, 3, 20, 16, 0),
+        "triggered_by": "CR log scan",
+        "status": "Active",
+        "details": '{"program":"PHOENIX","open_crs":3,"total_value":1200000}',
+        "financial_impact": 1_200_000,
+        "outcome_notes": "Repricing in flight",
+    },
+    {
+        "scenario_name": "Rate Card Drift",
+        "execution_date": datetime(2026, 3, 25, 14, 45),
+        "triggered_by": "Rate card diff",
+        "status": "Mitigating",
+        "details": '{"program":"ORION","drift_pct":0.20,"tier":"Senior Architect"}',
+        "financial_impact": 150_000,
+        "outcome_notes": "Refresh scheduled with procurement",
+    },
+    {
+        "scenario_name": "Attrition Wave",
+        "execution_date": datetime(2026, 3, 15, 10, 0),
+        "triggered_by": "HRIS feed",
+        "status": "Active",
+        "details": '{"program":"TITAN","rolling_12m_attrition":0.27,"threshold":0.15}',
+        "financial_impact": 220_000,
+        "outcome_notes": "Backfill + retention bonus approved",
+    },
+    {
+        "scenario_name": "SLA Breach Pattern",
+        "execution_date": datetime(2026, 3, 10, 18, 30),
+        "triggered_by": "Incident ledger",
+        "status": "Active",
+        "details": '{"program":"TITAN","p1_breaches_90d":2,"penalty_ytd":400000}',
+        "financial_impact": 400_000,
+        "outcome_notes": "On-call roster refresh + runbook overhaul",
+    },
+    {
+        "scenario_name": "Customer Satisfaction Drift",
+        "execution_date": datetime(2026, 4, 1, 8, 0),
+        "triggered_by": "Monthly survey",
+        "status": "Monitoring",
+        "details": '{"program":"ORION","csat_delta":-2.7,"nps_delta":-55}',
+        "financial_impact": 0,
+        "outcome_notes": "Voice-of-customer review set for next steering",
+    },
+    {
+        "scenario_name": "AI Trust Regression",
+        "execution_date": datetime(2026, 3, 30, 15, 15),
+        "triggered_by": "Trust score batch",
+        "status": "Active",
+        "details": '{"program":"PHOENIX","composite_delta":-8,"failing_gates":["parity","rework"]}',
+        "financial_impact": 0,
+        "outcome_notes": "Model prompt refresh scheduled",
+    },
+]
+
+
+class ResourcePoolSeed(TypedDict):
+    name: str
+    role: str
+    role_tier: str
+    skill_set: str
+    current_program_code: str | None
+    current_project_code: str | None
+    utilization_pct: float
+    bench_days: int
+    loaded_cost_annual: float
+    status: str
+
+
+RESOURCE_POOL: list[ResourcePoolSeed] = [
+    {"name": "Priya Sharma", "role": "Senior Engineer", "role_tier": "Senior", "skill_set": "Java, Spring, AWS", "current_program_code": "PHOENIX", "current_project_code": "PHOE-CBM", "utilization_pct": 82, "bench_days": 0, "loaded_cost_annual": 780_000, "status": "Active"},
+    {"name": "Raj Kumar", "role": "Tech Lead", "role_tier": "Senior", "skill_set": "Kafka, Integration, Architecture", "current_program_code": "PHOENIX", "current_project_code": "PHOE-INT", "utilization_pct": 90, "bench_days": 0, "loaded_cost_annual": 920_000, "status": "Active"},
+    {"name": "Meera Iyer", "role": "Data Engineer", "role_tier": "Senior", "skill_set": "Airflow, dbt, Snowflake", "current_program_code": "ORION", "current_project_code": "ORN-INGEST", "utilization_pct": 62, "bench_days": 35, "loaded_cost_annual": 840_000, "status": "Active"},
+    {"name": "Suresh Menon", "role": "Engineering Manager", "role_tier": "Senior", "skill_set": "AI tooling, Delivery", "current_program_code": "SENTINEL", "current_project_code": "SNTL-AUTO", "utilization_pct": 95, "bench_days": 0, "loaded_cost_annual": 1_100_000, "status": "Active"},
+    {"name": "Nisha Rao", "role": "SRE Lead", "role_tier": "Senior", "skill_set": "Kubernetes, SLOs, Incident Mgmt", "current_program_code": "TITAN", "current_project_code": "TTN-STORE", "utilization_pct": 88, "bench_days": 0, "loaded_cost_annual": 960_000, "status": "Active"},
+    {"name": "Anand Verma", "role": "Mid Engineer", "role_tier": "Mid", "skill_set": "Python, Airflow, Data Modelling", "current_program_code": "ORION", "current_project_code": "ORN-INGEST", "utilization_pct": 55, "bench_days": 42, "loaded_cost_annual": 560_000, "status": "Active"},
+    {"name": "Kavya Nair", "role": "Mid Engineer", "role_tier": "Mid", "skill_set": "React, GraphQL, Shopify", "current_program_code": "TITAN", "current_project_code": "TTN-STORE", "utilization_pct": 85, "bench_days": 0, "loaded_cost_annual": 620_000, "status": "Active"},
+    {"name": "Divya Menon", "role": "QA Lead", "role_tier": "Senior", "skill_set": "Playwright, Python, Test Architecture", "current_program_code": "SENTINEL", "current_project_code": "SNTL-AUTO", "utilization_pct": 92, "bench_days": 0, "loaded_cost_annual": 780_000, "status": "Active"},
+    {"name": "Vikram Rao", "role": "Junior Developer", "role_tier": "Junior", "skill_set": "Java, Spring Boot", "current_program_code": None, "current_project_code": None, "utilization_pct": 0, "bench_days": 28, "loaded_cost_annual": 420_000, "status": "Bench"},
+    {"name": "Ananya Desai", "role": "Junior Developer", "role_tier": "Junior", "skill_set": "Python, Data", "current_program_code": None, "current_project_code": None, "utilization_pct": 0, "bench_days": 14, "loaded_cost_annual": 400_000, "status": "Bench"},
+]
+
+
+class AuditLogSeed(TypedDict):
+    action: str
+    table_name: str
+    record_id: int
+    old_value: str | None
+    new_value: str | None
+    user_action: str
+    timestamp: datetime
+
+
+AUDIT_LOG: list[AuditLogSeed] = [
+    {"action": "UPDATE", "table_name": "programs", "record_id": 1, "old_value": '{"status":"Active"}', "new_value": '{"status":"At Risk"}', "user_action": "Status downgrade on integration vendor slip", "timestamp": datetime(2026, 3, 2, 10, 15)},
+    {"action": "INSERT", "table_name": "scope_creep_log", "record_id": 1, "old_value": None, "new_value": '{"program":"PHOENIX","cr_value":375000}', "user_action": "CR logged by Priya Sharma", "timestamp": datetime(2026, 2, 15, 14, 10)},
+    {"action": "UPDATE", "table_name": "customer_satisfaction", "record_id": 10, "old_value": '{"csat":7.2}', "new_value": '{"csat":6.7}', "user_action": "Monthly survey ingest", "timestamp": datetime(2026, 3, 31, 23, 30)},
+    {"action": "INSERT", "table_name": "ai_override_log", "record_id": 3, "old_value": None, "new_value": '{"tool":"Claude for Devs","type":"Rejected suggestion"}', "user_action": "Override captured by Raj Kumar", "timestamp": datetime(2026, 3, 22, 16, 45)},
+    {"action": "UPDATE", "table_name": "rate_cards", "record_id": 7, "old_value": '{"actual_rate":195}', "new_value": '{"actual_rate":210}', "user_action": "Quarterly rate refresh", "timestamp": datetime(2026, 3, 25, 11, 0)},
+    {"action": "INSERT", "table_name": "sla_incidents", "record_id": 2, "old_value": None, "new_value": '{"incident":"INC-2026-0587","priority":"P1"}', "user_action": "PagerDuty → audit sink", "timestamp": datetime(2026, 3, 4, 19, 52)},
+    {"action": "UPDATE", "table_name": "kpi_definitions", "record_id": 5, "old_value": '{"weight":1.5}', "new_value": '{"weight":1.8}', "user_action": "KPI Studio weight edit", "timestamp": datetime(2026, 3, 28, 9, 40)},
+    {"action": "DELETE", "table_name": "change_requests", "record_id": 99, "old_value": '{"description":"Abandoned CR"}', "new_value": None, "user_action": "CAB rollback", "timestamp": datetime(2026, 3, 15, 12, 20)},
+]

--- a/backend/app/seed/seeder.py
+++ b/backend/app/seed/seeder.py
@@ -16,6 +16,7 @@ from app.models import (
     AiTrustScore,
     AiUsageMetrics,
     AppSetting,
+    AuditLog,
     CommercialScenario,
     CurrencyRate,
     CustomerAction,
@@ -31,7 +32,9 @@ from app.models import (
     Project,
     ProjectPhase,
     RateCard,
+    ResourcePool,
     Risk,
+    ScenarioExecution,
     ScopeCreepLog,
     SlaIncident,
     SprintData,
@@ -75,6 +78,11 @@ from app.seed.delivery_data import (
     MILESTONES,
     PROJECT_PHASES,
     SPRINTS,
+)
+from app.seed.ops_data import (
+    AUDIT_LOG,
+    RESOURCE_POOL,
+    SCENARIO_EXECUTIONS,
 )
 
 log = get_logger(__name__)
@@ -121,6 +129,9 @@ async def seed_demo_data(session: AsyncSession, *, force: bool = False) -> bool:
     await _seed_ai_trust_scores(session, program_ids, ai_tool_ids)
     await _seed_ai_governance_config(session, program_ids)
     await _seed_ai_override_log(session, program_ids, project_ids, ai_tool_ids)
+    await _seed_scenario_executions(session)
+    await _seed_resource_pool(session, program_ids, project_ids)
+    await _seed_audit_log(session)
 
     await session.commit()
     log.info(
@@ -152,6 +163,9 @@ async def seed_demo_data(session: AsyncSession, *, force: bool = False) -> bool:
         ai_trust_rows=len(AI_TRUST_SCORES),
         ai_governance_rows=len(AI_GOVERNANCE_CONFIG),
         ai_overrides=len(AI_OVERRIDE_LOG),
+        scenarios=len(SCENARIO_EXECUTIONS),
+        resources=len(RESOURCE_POOL),
+        audit_entries=len(AUDIT_LOG),
     )
     return True
 
@@ -626,3 +640,31 @@ async def _seed_ai_override_log(
                 **payload,
             )
         )
+
+
+async def _seed_scenario_executions(session: AsyncSession) -> None:
+    for data in SCENARIO_EXECUTIONS:
+        session.add(ScenarioExecution(**data))
+
+
+async def _seed_resource_pool(
+    session: AsyncSession,
+    program_ids: dict[str, int],
+    project_ids: dict[str, int],
+) -> None:
+    for data in RESOURCE_POOL:
+        payload = dict(data)
+        program_code = payload.pop("current_program_code", None)
+        project_code = payload.pop("current_project_code", None)
+        session.add(
+            ResourcePool(
+                current_program_id=program_ids.get(program_code) if program_code else None,
+                current_project_id=project_ids.get(project_code) if project_code else None,
+                **payload,
+            )
+        )
+
+
+async def _seed_audit_log(session: AsyncSession) -> None:
+    for data in AUDIT_LOG:
+        session.add(AuditLog(**data))

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,7 @@ ignore = ["PLR0913", "PLR2004"]
 "app/seed/commercial_data.py" = ["E501"]
 "app/seed/customer_data.py" = ["E501"]
 "app/seed/ai_data.py" = ["E501"]
+"app/seed/ops_data.py" = ["E501"]
 "app/seed/seeder.py" = ["PLR0913"]
 "app/api/**" = ["B008"]        # FastAPI `Depends(...)` in defaults is idiomatic
 "app/database.py" = ["PLW0603"] # module-level engine cache is deliberate

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import { DeliveryHealth } from "@/pages/DeliveryHealth";
 import { KpiStudio } from "@/pages/KpiStudio";
 import { MarginEvm } from "@/pages/MarginEvm";
 import { NotFound } from "@/pages/NotFound";
+import { RiskAudit } from "@/pages/RiskAudit";
+import { SmartOps } from "@/pages/SmartOps";
 import { VelocityFlow } from "@/pages/VelocityFlow";
 
 const router = createBrowserRouter([
@@ -24,6 +26,8 @@ const router = createBrowserRouter([
       { path: "margin", element: <MarginEvm /> },
       { path: "customer", element: <CustomerIntelligence /> },
       { path: "ai", element: <AiGovernance /> },
+      { path: "smart-ops", element: <SmartOps /> },
+      { path: "raid", element: <RiskAudit /> },
       { path: "data-hub", element: <DataHub /> },
       { path: "*", element: <NotFound /> },
     ],

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,8 +11,8 @@ const tabs = [
   { to: "/margin", label: "Margin & EVM", num: "05" },
   { to: "/customer", label: "Customer", num: "06" },
   { to: "/ai", label: "AI Governance", num: "07" },
-  { to: "/smart-ops", label: "Smart Ops", num: "08", disabled: true },
-  { to: "/raid", label: "Risk & Audit", num: "09", disabled: true },
+  { to: "/smart-ops", label: "Smart Ops", num: "08" },
+  { to: "/raid", label: "Risk & Audit", num: "09" },
   { to: "/reports", label: "Reports", num: "10", disabled: true },
   { to: "/data-hub", label: "Data Hub", num: "11" },
 ];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -675,6 +675,69 @@ export async function fetchAiOverrides(programId?: number): Promise<AiOverride[]
   return data;
 }
 
+// ---------- Smart Ops + Risk & Audit ----------
+
+export type ScenarioExecution = {
+  id: number;
+  scenario_name: string;
+  execution_date: string | null;
+  triggered_by: string | null;
+  status: string | null;
+  details: string | null;
+  financial_impact: number | null;
+  outcome_notes: string | null;
+};
+
+export type ResourceRow = {
+  id: number;
+  name: string;
+  role: string | null;
+  role_tier: string | null;
+  skill_set: string | null;
+  current_program_id: number | null;
+  current_project_id: number | null;
+  utilization_pct: number | null;
+  bench_days: number;
+  loaded_cost_annual: number | null;
+  status: string;
+};
+
+export type AuditEntry = {
+  id: number;
+  action: string | null;
+  table_name: string | null;
+  record_id: number | null;
+  old_value: string | null;
+  new_value: string | null;
+  user_action: string | null;
+  timestamp: string;
+};
+
+export async function fetchScenarios(status?: string): Promise<ScenarioExecution[]> {
+  const { data } = await api.get<ScenarioExecution[]>(
+    "/api/v1/smart-ops/scenarios",
+    { params: status ? { status } : undefined },
+  );
+  return data;
+}
+
+export async function fetchResources(benchOnly = false): Promise<ResourceRow[]> {
+  const { data } = await api.get<ResourceRow[]>("/api/v1/smart-ops/resources", {
+    params: benchOnly ? { bench_only: true } : undefined,
+  });
+  return data;
+}
+
+export async function fetchAuditLog(
+  tableName?: string,
+  limit = 50,
+): Promise<AuditEntry[]> {
+  const { data } = await api.get<AuditEntry[]>("/api/v1/audit", {
+    params: { table_name: tableName, limit },
+  });
+  return data;
+}
+
 export async function previewCsv(file: File): Promise<{
   filename: string;
   columns: string[];

--- a/frontend/src/pages/RiskAudit.tsx
+++ b/frontend/src/pages/RiskAudit.tsx
@@ -1,0 +1,403 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { ClipboardList, FileText, Home, ShieldCheck } from "lucide-react";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import {
+  fetchAiGovernance,
+  fetchAuditLog,
+  fetchTopRisks,
+} from "@/lib/api";
+import { useProgrammes } from "@/hooks/usePortfolio";
+import { useCurrency } from "@/hooks/useCurrency";
+import { formatDate, formatPct, type RagBucket } from "@/lib/format";
+
+function riskSeverityTone(severity: string | null): RagBucket {
+  const s = (severity ?? "").toLowerCase();
+  if (s === "high" || s === "critical") return "red";
+  if (s === "medium") return "amber";
+  return "green";
+}
+
+export function RiskAudit() {
+  const [tableFilter, setTableFilter] = useState<string | null>(null);
+  const programmes = useProgrammes();
+  const currency = useCurrency();
+
+  const risks = useQuery({
+    queryKey: ["risks", "all", 50],
+    queryFn: () => fetchTopRisks(50),
+  });
+  const audit = useQuery({
+    queryKey: ["audit", tableFilter],
+    queryFn: () => fetchAuditLog(tableFilter ?? undefined, 100),
+  });
+  const governance = useQuery({
+    queryKey: ["audit-governance"],
+    queryFn: () => fetchAiGovernance(),
+  });
+
+  const auditTables = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of audit.data ?? []) {
+      if (a.table_name) set.add(a.table_name);
+    }
+    return [...set].sort();
+  }, [audit.data]);
+
+  const programmeByName = useMemo(
+    () =>
+      new Map(
+        (programmes.data ?? []).map((p) => [p.id, { code: p.code, name: p.name, currency_code: p.currency_code }]),
+      ),
+    [programmes.data],
+  );
+
+  const risksByProgramme = useMemo(() => {
+    const buckets = new Map<string, { count: number; impact: number }>();
+    for (const r of risks.data ?? []) {
+      const code =
+        r.program_id !== null ? programmeByName.get(r.program_id)?.code ?? "—" : "—";
+      const row = buckets.get(code) ?? { count: 0, impact: 0 };
+      row.count += 1;
+      row.impact += r.impact ?? 0;
+      buckets.set(code, row);
+    }
+    return Array.from(buckets.entries()).map(([code, v]) => ({
+      code,
+      count: v.count,
+      impact: v.impact,
+    }));
+  }, [risks.data, programmeByName]);
+
+  const complianceByControl = useMemo(() => {
+    return (governance.data ?? []).map((g) => ({
+      control: g.name,
+      complianceDisplay: g.compliance_pct ?? 0,
+      compliance: (g.compliance_pct ?? 0) / 100,
+    }));
+  }, [governance.data]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Breadcrumb
+        items={[
+          { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
+          { label: "Risk & Audit" },
+        ]}
+      />
+
+      <div>
+        <h1 className="text-2xl font-semibold text-navy">Risk & Audit</h1>
+        <p className="mt-1 text-sm text-navy/70">
+          If an auditor walked in today, could we demonstrate governance?
+          RAID register, compliance scorecard, data-change trail.
+        </p>
+      </div>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <Stat label="Open risks" value={`${risks.data?.length ?? 0}`} />
+        <Stat
+          label="Controls tracked"
+          value={`${governance.data?.length ?? 0}`}
+          sub={`${(governance.data ?? []).filter((g) => g.config_type === "policy").length} policies · ${(governance.data ?? []).filter((g) => g.config_type === "control").length} controls`}
+        />
+        <Stat
+          label="Audit entries"
+          value={`${audit.data?.length ?? 0}`}
+          sub={`${auditTables.length} tables tracked`}
+        />
+        <Stat
+          label="Risk-weighted exposure"
+          value={currency.format(
+            (risks.data ?? []).reduce(
+              (sum, r) => sum + (r.impact ?? 0) * (r.probability ?? 0),
+              0,
+            ),
+            "INR",
+          )}
+          sub="Σ impact × probability"
+        />
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Risk register"
+          subtitle="All open and mitigated risks across the portfolio"
+        />
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase text-navy/60">
+                <th className="py-2">Title</th>
+                <th>Programme</th>
+                <th>Category</th>
+                <th>Severity</th>
+                <th className="text-right">Probability</th>
+                <th className="text-right">Impact</th>
+                <th>Owner</th>
+                <th>Mitigation</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(risks.data ?? []).map((r) => {
+                const programmeInfo =
+                  r.program_id !== null ? programmeByName.get(r.program_id) : null;
+                return (
+                  <tr key={r.id} className="border-t border-ice-100 align-top">
+                    <td className="py-2 font-medium">{r.title}</td>
+                    <td>{programmeInfo?.code ?? "—"}</td>
+                    <td>{r.category ?? "—"}</td>
+                    <td>
+                      <Badge tone={riskSeverityTone(r.severity)}>{r.severity ?? "—"}</Badge>
+                    </td>
+                    <td className="text-right font-mono">
+                      {r.probability === null ? "—" : formatPct(r.probability)}
+                    </td>
+                    <td className="text-right font-mono">
+                      {currency.format(r.impact, programmeInfo?.currency_code ?? "INR")}
+                    </td>
+                    <td>{r.owner ?? "—"}</td>
+                    <td className="text-xs text-navy/70">{r.mitigation_plan ?? "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader
+            title="Risk exposure by programme"
+            subtitle="Count + summed impact"
+          />
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={risksByProgramme}
+                margin={{ top: 8, right: 24, left: 0, bottom: 8 }}
+              >
+                <CartesianGrid stroke="#E4EEF4" strokeDasharray="4 4" />
+                <XAxis dataKey="code" stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+                <YAxis
+                  yAxisId="left"
+                  stroke="#1B2A4A"
+                  tick={{ fontSize: 12 }}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  stroke="#F59E0B"
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={(v) => currency.format(Number(v), "INR")}
+                />
+                <Tooltip
+                  contentStyle={{ border: "1px solid #D5E8F0" }}
+                  formatter={(value: number, name: string) =>
+                    name === "Impact Σ"
+                      ? currency.format(value, "INR")
+                      : value
+                  }
+                />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar yAxisId="left" dataKey="count" name="Risk count" fill="#1B2A4A" />
+                <Bar yAxisId="right" dataKey="impact" name="Impact Σ" fill="#F59E0B" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
+
+        <Card>
+          <CardHeader
+            title="Compliance scorecard"
+            subtitle="Compliance % per governance control"
+            action={<ShieldCheck className="size-4 text-success-600" aria-hidden="true" />}
+          />
+          {complianceByControl.length === 0 ? (
+            <p className="text-sm text-navy/60">No governance rows loaded yet.</p>
+          ) : (
+            <ul className="flex flex-col gap-2 text-sm">
+              {complianceByControl.map((row) => (
+                <li
+                  key={row.control}
+                  className="flex items-center justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2"
+                >
+                  <p className="font-medium">{row.control}</p>
+                  <Badge
+                    tone={
+                      row.complianceDisplay >= 95
+                        ? "green"
+                        : row.complianceDisplay >= 80
+                          ? "amber"
+                          : "red"
+                    }
+                  >
+                    {formatPct(row.compliance)}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Audit trail"
+          subtitle={`Last ${audit.data?.length ?? 0} entries — filter by affected table`}
+          action={
+            <div className="flex flex-wrap gap-1">
+              <button
+                type="button"
+                onClick={() => setTableFilter(null)}
+                className={`rounded-full px-3 py-1 text-xs transition ${
+                  tableFilter === null ? "bg-navy text-white" : "bg-ice-50 text-navy hover:bg-ice-100"
+                }`}
+              >
+                All
+              </button>
+              {auditTables.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTableFilter(t)}
+                  className={`rounded-full px-3 py-1 text-xs transition ${
+                    tableFilter === t ? "bg-navy text-white" : "bg-ice-50 text-navy hover:bg-ice-100"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          }
+        />
+        {(audit.data ?? []).length === 0 ? (
+          <p className="text-sm text-navy/60">No audit entries match the filter.</p>
+        ) : (
+          <ul className="flex flex-col gap-2 text-sm">
+            {(audit.data ?? []).map((a) => (
+              <li
+                key={a.id}
+                className="flex items-start gap-3 rounded border border-ice-100 bg-white px-3 py-2"
+              >
+                <FileText className="mt-0.5 size-3 text-navy/60" aria-hidden="true" />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <Badge tone={a.action === "DELETE" ? "red" : a.action === "UPDATE" ? "amber" : "neutral"}>
+                      {a.action ?? "—"}
+                    </Badge>
+                    <span className="font-mono text-xs">{a.table_name ?? "—"}</span>
+                    <span className="text-xs text-navy/60">
+                      #{a.record_id ?? "—"}
+                    </span>
+                  </div>
+                  <p className="text-xs text-navy/70">{a.user_action ?? "—"}</p>
+                  {a.old_value || a.new_value ? (
+                    <p className="mt-1 font-mono text-[11px] text-navy/60">
+                      {a.old_value ? <span className="text-danger-600">{a.old_value}</span> : null}
+                      {a.old_value && a.new_value ? " → " : null}
+                      {a.new_value ? <span className="text-success-600">{a.new_value}</span> : null}
+                    </p>
+                  ) : null}
+                </div>
+                <span className="text-xs text-navy/60">
+                  {formatDate(a.timestamp)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="Audit readiness scorecard"
+          subtitle="What the auditor asks · where the evidence lives"
+          action={<ClipboardList className="size-4 text-navy/60" aria-hidden="true" />}
+        />
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase text-navy/60">
+                <th className="py-2">Dimension</th>
+                <th>Auditor asks</th>
+                <th>Evidence source</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <AuditRow dimension="Financial Controls" ask="Are costs tracked against budget?" source="evm_snapshots + commercial_scenarios" status="Monthly CPI/SPI available" tone="green" />
+              <AuditRow dimension="AI Governance" ask="Is AI output reviewed before production?" source="ai_override_log + ai_code_metrics" status="Branch protection + reviewer gate" tone="green" />
+              <AuditRow dimension="Risk Management" ask="Are risks identified, assessed, mitigated?" source="risks + risk_history" status="All risks have owner + plan" tone="green" />
+              <AuditRow dimension="Change Management" ask="Are changes tracked and approved?" source="scope_creep_log + audit_log" status="All CRs logged with CAB approval" tone="amber" />
+              <AuditRow dimension="Quality Assurance" ask="Is quality measured and improving?" source="sprint_data (defects, rework)" status="Sentinel improving; Phoenix trending amber" tone="amber" />
+              <AuditRow dimension="Process Adherence" ask="Are governance meetings happening?" source="customer_satisfaction (meeting tracker)" status="≥90% for Atlas/Sentinel/Titan" tone="green" />
+              <AuditRow dimension="Data Integrity" ask="Can you trace every number?" source="Data lineage + audit_log" status="Lineage documented, lineage tab planned in I-4" tone="amber" />
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function AuditRow({
+  dimension,
+  ask,
+  source,
+  status,
+  tone,
+}: {
+  dimension: string;
+  ask: string;
+  source: string;
+  status: string;
+  tone: RagBucket;
+}) {
+  return (
+    <tr className="border-t border-ice-100 align-top">
+      <td className="py-2 font-medium">{dimension}</td>
+      <td className="text-xs italic text-navy/70">{ask}</td>
+      <td className="font-mono text-xs">{source}</td>
+      <td>
+        <Badge tone={tone}>{status}</Badge>
+      </td>
+    </tr>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: "green" | "amber" | "red" | "neutral";
+}) {
+  return (
+    <div className="rounded border border-ice-100 bg-white px-3 py-2">
+      <span className="kpi-label">{label}</span>
+      <div className="flex items-center gap-2">
+        <p className="font-mono text-xl font-semibold text-navy">{value}</p>
+        {tone && tone !== "neutral" ? <Badge tone={tone}>·</Badge> : null}
+      </div>
+      {sub ? <p className="text-xs text-navy/60">{sub}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/SmartOps.tsx
+++ b/frontend/src/pages/SmartOps.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertOctagon, CheckCircle2, Clock, Home, Users } from "lucide-react";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import {
+  fetchResources,
+  fetchScenarios,
+  type ScenarioExecution,
+  type ResourceRow,
+} from "@/lib/api";
+import { useCurrency } from "@/hooks/useCurrency";
+import { formatPct, type RagBucket } from "@/lib/format";
+
+const STATUS_TONE: Record<string, RagBucket | "neutral"> = {
+  Active: "red",
+  Mitigating: "amber",
+  Monitoring: "amber",
+  Resolved: "green",
+  Acknowledged: "neutral",
+};
+
+export function SmartOps() {
+  const [filter, setFilter] = useState<string | null>(null);
+  const scenarios = useQuery({
+    queryKey: ["scenarios", filter],
+    queryFn: () => fetchScenarios(filter ?? undefined),
+  });
+  const resources = useQuery({
+    queryKey: ["resources"],
+    queryFn: () => fetchResources(),
+  });
+  const currency = useCurrency();
+
+  const activeCount = (scenarios.data ?? []).filter(
+    (s) => s.status === "Active",
+  ).length;
+  const mitigatingCount = (scenarios.data ?? []).filter(
+    (s) => s.status === "Mitigating",
+  ).length;
+  const totalFinancialImpact = (scenarios.data ?? []).reduce(
+    (sum, s) => sum + (s.financial_impact ?? 0),
+    0,
+  );
+  const bench = (resources.data ?? []).filter((r) => r.status === "Bench");
+  const benchCost = bench.reduce(
+    (sum, r) => sum + ((r.loaded_cost_annual ?? 0) / 365) * r.bench_days,
+    0,
+  );
+
+  const statuses = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of scenarios.data ?? []) {
+      if (s.status) set.add(s.status);
+    }
+    return [...set].sort();
+  }, [scenarios.data]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Breadcrumb
+        items={[
+          { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
+          { label: "Smart Ops" },
+        ]}
+      />
+
+      <div>
+        <h1 className="text-2xl font-semibold text-navy">Smart Ops</h1>
+        <p className="mt-1 text-sm text-navy/70">
+          8 proactive-detection scenarios running continuously over the
+          portfolio. Each triggered alert surfaces a financial impact
+          estimate and a suggested action.
+        </p>
+      </div>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <Stat label="Active alerts" value={`${activeCount}`} tone={activeCount === 0 ? "green" : "red"} />
+        <Stat label="Mitigating" value={`${mitigatingCount}`} tone={mitigatingCount > 0 ? "amber" : "green"} />
+        <Stat
+          label="Financial impact"
+          value={currency.format(totalFinancialImpact, "INR")}
+          sub="Sum across active + mitigating alerts"
+        />
+        <Stat
+          label="Bench cost (YTD-ish)"
+          value={currency.format(benchCost, "INR")}
+          sub={`${bench.length} FTE on bench`}
+        />
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Scenario alerts"
+          subtitle="Filter by status"
+          action={
+            <div className="flex flex-wrap gap-1">
+              <button
+                type="button"
+                onClick={() => setFilter(null)}
+                className={`rounded-full px-3 py-1 text-xs transition ${
+                  filter === null ? "bg-navy text-white" : "bg-ice-50 text-navy hover:bg-ice-100"
+                }`}
+              >
+                All
+              </button>
+              {statuses.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setFilter(s)}
+                  className={`rounded-full px-3 py-1 text-xs transition ${
+                    filter === s ? "bg-navy text-white" : "bg-ice-50 text-navy hover:bg-ice-100"
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          }
+        />
+        {(scenarios.data ?? []).length === 0 ? (
+          <p className="text-sm text-navy/60">No scenario executions match the filter.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {(scenarios.data ?? []).map((s) => (
+              <ScenarioRow key={s.id} scenario={s} sourceCurrency="INR" />
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="Resource pool"
+          subtitle={`${resources.data?.length ?? 0} people · ${bench.length} on bench`}
+          action={<Users className="size-4 text-navy/60" aria-hidden="true" />}
+        />
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs uppercase text-navy/60">
+                <th className="py-2">Name</th>
+                <th>Role</th>
+                <th>Tier</th>
+                <th className="text-right">Utilisation</th>
+                <th className="text-right">Bench days</th>
+                <th className="text-right">Loaded cost/yr</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(resources.data ?? []).map((r) => (
+                <ResourceRowView key={r.id} row={r} currencyFormat={currency.format} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function ScenarioRow({
+  scenario,
+  sourceCurrency,
+}: {
+  scenario: ScenarioExecution;
+  sourceCurrency: string;
+}) {
+  const currency = useCurrency();
+  const tone = STATUS_TONE[scenario.status ?? ""] ?? "neutral";
+  return (
+    <li className="flex items-start justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2">
+      <div className="flex flex-1 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <AlertOctagon
+            className={`size-4 ${
+              scenario.status === "Active" ? "text-danger-600" : "text-amber-500"
+            }`}
+            aria-hidden="true"
+          />
+          <span className="font-semibold">{scenario.scenario_name}</span>
+          <Badge tone={tone}>{scenario.status ?? "—"}</Badge>
+        </div>
+        {scenario.details ? (
+          <p className="rounded bg-ice-50 px-2 py-1 font-mono text-xs">{scenario.details}</p>
+        ) : null}
+        {scenario.outcome_notes ? (
+          <p className="text-xs italic text-navy/70">Action: {scenario.outcome_notes}</p>
+        ) : null}
+        <p className="text-xs text-navy/60">
+          <Clock className="inline size-3" aria-hidden="true" />{" "}
+          {scenario.execution_date
+            ? new Date(scenario.execution_date).toLocaleString("en-GB")
+            : "—"}
+          {" · "}
+          triggered by {scenario.triggered_by ?? "—"}
+        </p>
+      </div>
+      <div className="text-right font-mono text-sm">
+        {currency.format(scenario.financial_impact, sourceCurrency)}
+      </div>
+    </li>
+  );
+}
+
+function ResourceRowView({
+  row,
+  currencyFormat,
+}: {
+  row: ResourceRow;
+  currencyFormat: (amount: number | null, src: string) => string;
+}) {
+  return (
+    <tr className="border-t border-ice-100">
+      <td className="py-2 font-medium">{row.name}</td>
+      <td>{row.role ?? "—"}</td>
+      <td>{row.role_tier ?? "—"}</td>
+      <td className="text-right font-mono">
+        {row.utilization_pct === null ? "—" : formatPct(row.utilization_pct / 100)}
+      </td>
+      <td className="text-right font-mono">
+        <Badge tone={row.bench_days > 0 ? "red" : "green"}>
+          {row.bench_days === 0 ? (
+            <CheckCircle2 className="size-3" aria-hidden="true" />
+          ) : null}
+          {row.bench_days}d
+        </Badge>
+      </td>
+      <td className="text-right font-mono">
+        {currencyFormat(row.loaded_cost_annual, "INR")}
+      </td>
+      <td>
+        <Badge tone={row.status === "Bench" ? "red" : "green"}>{row.status}</Badge>
+      </td>
+    </tr>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: "green" | "amber" | "red" | "neutral";
+}) {
+  return (
+    <div className="rounded border border-ice-100 bg-white px-3 py-2">
+      <span className="kpi-label">{label}</span>
+      <div className="flex items-center gap-2">
+        <p className="font-mono text-xl font-semibold text-navy">{value}</p>
+        {tone && tone !== "neutral" ? <Badge tone={tone}>·</Badge> : null}
+      </div>
+      {sub ? <p className="text-xs text-navy/60">{sub}</p> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Ships the final two Iteration-3 tabs.

**Tab 8 Smart Ops** — 8 proactive-detection scenarios from ARCHITECTURE.md §11 surface as active/mitigating/monitoring alerts. Each shows JSON trigger details, financial impact, and the proposed action. Resource pool table exposes bench days + loaded cost for the Smart-Ops "Bench Tax" narrative.

**Tab 9 Risk & Audit** — full risk register, compliance scorecard, filtered audit trail with old→new diff, and the 7-dimension audit-readiness matrix mapping auditor questions to evidence sources.

## Backend
- 3 new endpoints: `/api/v1/smart-ops/scenarios`, `/smart-ops/resources`, `/audit`.
- New seed `app/seed/ops_data.py`: 8 scenario executions, 10 resource_pool rows (2 bench), 8 representative audit_log entries.

## Frontend
- Tab 8 (`/smart-ops`): status-filter chips, scenario cards with JSON trigger detail + financial impact, resource pool table.
- Tab 9 (`/raid`): risk register (drillable later), risks-by-programme dual-axis bar, compliance scorecard per governance control, filtered audit trail with old/new diff, audit-readiness scorecard (7 dimensions × evidence source).

## Quality gates
- pytest **33/33** · ruff + ESLint clean · build green
- Docker smoke: scenarios=8 (6 active), bench=2 FTE, audit first-5 tables span 5 distinct source tables.

## Where we stand
Tabs **01–09 + 11 live**. Only Tab 10 (Reports & Exports) remains — slated for Iteration 4 alongside predictive analytics, E2E tests, accessibility pass, and SBOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)