### PR TITLE
feat: Iteration 3d — Standardised drill nav v3 + runbook

### DIFF
--- a/docs/RUN_BOOK.md
+++ b/docs/RUN_BOOK.md
@@ -1,0 +1,261 @@
+# AKB1 Command Center — Run Book
+
+**Audience:** Adi (primary operator) · any future contributor who clones the repo
+**Goal:** Boot the dashboard from a cold Mac in ≤ 3 minutes and keep it reachable as a daily driver.
+
+---
+
+## TL;DR — every time you sit down
+
+```bash
+cd ~/Documents/Claude/Claude_Code/Projects/akb1-command-center
+docker compose up -d
+open http://localhost:9000
+```
+
+That's it. The backend seeds on first boot; subsequent boots reuse the SQLite volume.
+
+To stop:
+
+```bash
+docker compose down
+```
+
+Data persists (SQLite volume `akb1-data`). Use `down -v` only when you want a clean slate.
+
+---
+
+## 1. Prerequisites (one-time setup)
+
+| Tool | Install | Verify |
+|---|---|---|
+| Docker Desktop | `brew install --cask docker` (or download from docker.com) | `docker info` shows a server version |
+| Git | `xcode-select --install` | `git --version` |
+| GitHub CLI (optional — only for PRs) | `brew install gh` → `gh auth login` | `gh auth status` |
+| Node 20 (optional — only for frontend dev outside Docker) | `brew install node@20` | `node --version` → `v20.x` |
+| Python 3.12 (optional — only for backend dev outside Docker) | `brew install python@3.12` | `python3.12 --version` |
+
+Ports **9000** and **9001** must be free on `127.0.0.1`. If another app is using them, edit `.env` (see §5).
+
+---
+
+## 2. Daily workflow
+
+### 2.1 Start the stack
+
+```bash
+cd ~/Documents/Claude/Claude_Code/Projects/akb1-command-center
+docker compose up -d
+```
+
+`up -d` puts the containers in the background. First run takes ~90 s (build); subsequent runs take ~5 s.
+
+### 2.2 Check health
+
+```bash
+docker ps | grep akb1                      # two containers, status "healthy"
+curl http://localhost:9000/health            # {"status":"healthy","version":"5.2.0","tables":44}
+```
+
+### 2.3 Open in the browser
+
+```bash
+open http://localhost:9000                   # macOS default browser
+```
+
+Useful deep-links:
+
+| URL | What it shows |
+|---|---|
+| `http://localhost:9000/` | Executive Overview (Tab 1) |
+| `http://localhost:9000/kpi` | KPI Studio (Tab 2) |
+| `http://localhost:9000/delivery?programme=PHOENIX` | Delivery Health pre-filtered to Phoenix |
+| `http://localhost:9000/customer?programme=ORION` | Customer Intelligence on Orion |
+| `http://localhost:9001/docs` | FastAPI Swagger UI (auto-generated) |
+
+### 2.4 Stop the stack
+
+```bash
+docker compose down                          # keeps the data volume
+docker compose down -v                       # also drops the volume (will re-seed next run)
+```
+
+---
+
+## 3. Auto-start on login (macOS)
+
+Copy the provided LaunchAgent into your user agents directory and load it once:
+
+```bash
+mkdir -p ~/Library/LaunchAgents
+cp scripts/com.akb1.dashboard.plist ~/Library/LaunchAgents/
+launchctl load -w ~/Library/LaunchAgents/com.akb1.dashboard.plist
+```
+
+After that, every time you log in macOS will run `docker compose up -d` in the project folder automatically. Stops/starts Docker Desktop itself? Launchctl retries once Docker is available (delay configurable in the plist).
+
+Disable it temporarily:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.akb1.dashboard.plist
+```
+
+Re-enable:
+
+```bash
+launchctl load -w ~/Library/LaunchAgents/com.akb1.dashboard.plist
+```
+
+Uninstall completely:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.akb1.dashboard.plist
+rm ~/Library/LaunchAgents/com.akb1.dashboard.plist
+```
+
+LaunchAgent logs land in `/tmp/akb1-launch.log` — first place to look if the autostart misbehaves.
+
+---
+
+## 4. Common operations
+
+### 4.1 Refresh demo data (re-seed)
+
+```bash
+docker compose down -v                       # drop the volume
+docker compose up -d                         # backend detects empty DB and re-seeds
+```
+
+Rebuild the images first if you've pulled new backend code:
+
+```bash
+docker compose build backend frontend
+docker compose up -d
+```
+
+### 4.2 View live logs
+
+```bash
+docker compose logs -f backend               # tail backend (structlog JSON)
+docker compose logs -f frontend              # nginx access log
+docker compose logs -f                       # both
+```
+
+### 4.3 Run a one-off backend shell
+
+```bash
+docker compose exec backend sh               # UID 1001 (non-root) — read-only FS, /tmp is writable
+# …or SQL:
+docker compose exec backend python -c "
+import sqlite3; c = sqlite3.connect('/data/akb1.db'); print(c.execute('select count(*) from programs').fetchone())
+"
+```
+
+### 4.4 Export a DB snapshot
+
+```bash
+./scripts/export-db.sh                       # writes a timestamped .db to ./backups/
+```
+
+### 4.5 Pull updates from GitHub
+
+```bash
+git pull                                     # fast-forward
+docker compose build                         # rebuild changed images
+docker compose up -d --force-recreate        # apply new images
+```
+
+### 4.6 Switch display currency
+
+Use the **Base** dropdown in the top-right of the dashboard (`USD / INR / GBP / EUR`). All amounts recompute using seeded FX rates (USD = 1.0 anchor). Rate source is marked `seed` — see §6 for a live-refresh follow-up.
+
+---
+
+## 5. Configuration (`.env`)
+
+Copy `.env.example` to `.env` and override whatever you need. Common knobs:
+
+| Var | Default | Why change it |
+|---|---|---|
+| `FRONTEND_PORT` | `9000` | Another service squatting on 9000 |
+| `BACKEND_PORT` | `9001` | Another service squatting on 9001 |
+| `SEED_DEMO_DATA` | `true` | Set `false` on cold-boots after the DB is populated |
+| `DATABASE_URL` | `sqlite+aiosqlite:////data/akb1.db` | Point at a mounted path for backup/restore |
+| `CORS_ORIGINS` | `http://localhost:9000,http://127.0.0.1:9000` | Add a reverse-proxy host |
+| `LOG_LEVEL` | `info` | `debug` when chasing a bug |
+
+Changes require `docker compose up -d --force-recreate` to take effect.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Most likely cause | Fix |
+|---|---|---|
+| "Network Error" on the dashboard and `/health` is green | You opened a different hostname than the nginx proxy expects | Use `localhost` or `127.0.0.1` exactly — both are now CORS-allowed |
+| `docker compose up` hangs on pull | Network / Docker Hub throttle | Wait, or `docker compose build --pull=false` |
+| Backend container is "unhealthy" | Seed failed on first run (usually a schema change you ran in a previous version) | `docker compose down -v && docker compose up -d` |
+| Port 9000 or 9001 in use | Another service | Edit `.env` to pick free ports, `docker compose up -d --force-recreate` |
+| Charts render blank after a base-currency change | Stale React Query cache | Cmd+Shift+R to hard reload |
+| FX rates look stale | They are seeded 2026-04-20, not live | Manual edit via `docker compose exec backend python -c …` or wait for the planned `/currency/refresh` endpoint |
+| Daily backup is empty | `scripts/export-db.sh` permissions | `chmod +x scripts/*.sh` |
+
+Dig deeper:
+
+```bash
+docker compose ps --format 'table {{.Service}}\t{{.Status}}\t{{.Ports}}'
+docker logs akb1-backend --tail 100
+curl -s http://localhost:9001/health | jq
+curl -s http://localhost:9000/api/v1/programmes | jq length
+```
+
+---
+
+## 7. Developer mode (outside Docker)
+
+Only needed when you're iterating on code with hot reload.
+
+### 7.1 Backend
+
+```bash
+cd backend
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+SEED_DEMO_DATA=true DATABASE_URL=sqlite+aiosqlite:///data/akb1.db uvicorn app.main:app --reload --port 9001
+```
+
+Run the test suite: `pytest` · lint: `ruff check app tests` · coverage: `pytest --cov=app`
+
+### 7.2 Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev        # Vite on http://127.0.0.1:9000 with HMR
+```
+
+`npm run build` for the production bundle · `npm run lint` · `npm test` for Vitest.
+
+---
+
+## 8. Security reminders
+
+- The default compose file **binds every port to `127.0.0.1`**. The dashboard is not reachable from the LAN. If you want LAN access, drop the `127.0.0.1:` prefix in `docker-compose.yml` **and** terminate TLS via the Caddy overlay (`docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d`).
+- Containers run as UID 1001, read-only root filesystem, `cap_drop: ALL`. Don't undo these without reading `docs/SECURITY_GUIDE.md` §10.
+- `.env` is git-ignored. Never commit secrets. If you enable API-key auth (`API_KEY_ENABLED=true`), store only the SHA-256 hash in `API_KEY_HASH`, never the plaintext key.
+
+---
+
+## 9. Links
+
+| Thing | Where |
+|---|---|
+| GitHub repo | https://github.com/deva-adi/akb1-command-center |
+| OpenAPI docs | http://localhost:9001/docs |
+| Architecture | `docs/ARCHITECTURE.md` |
+| Wireframes | `docs/WIREFRAMES.md` |
+| Formulas | `docs/FORMULAS.md` |
+| Demo walkthrough | `docs/DEMO_GUIDE.md` |
+| Security posture | `docs/SECURITY_GUIDE.md` |
+| Contributor guide | `docs/CONTRIBUTING.md` |

--- a/frontend/src/components/ProgrammeFilterBar.tsx
+++ b/frontend/src/components/ProgrammeFilterBar.tsx
@@ -1,0 +1,119 @@
+import { useMemo } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { useProgrammes } from "@/hooks/usePortfolio";
+import type { Programme } from "@/lib/api";
+
+export type CrossTabLink = {
+  /** Route path, without the query string. */
+  to: string;
+  /** Shown to the user. */
+  label: string;
+};
+
+type Props = {
+  /** Route path of the page rendering this bar, used when navigating peers. */
+  currentRoute: string;
+  /** Cross-tab links surfaced when a programme filter is active. */
+  crossLinks?: CrossTabLink[];
+  /**
+   * Optional override when the page drives selection via local state instead of
+   * the `?programme=CODE` query param (e.g. CustomerIntelligence programme picker).
+   */
+  activeProgramme?: Programme | null;
+  /**
+   * Pure-local mode: if provided, prev/next + clear call this callback instead
+   * of rewriting the URL. The filter chip is still shown.
+   */
+  onSelect?: (programme: Programme | null) => void;
+};
+
+export function ProgrammeFilterBar({
+  currentRoute,
+  crossLinks = [],
+  activeProgramme,
+  onSelect,
+}: Props) {
+  const programmes = useProgrammes();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const codeFromUrl = searchParams.get("programme");
+
+  const fromUrl = useMemo(
+    () => programmes.data?.find((p) => p.code === codeFromUrl) ?? null,
+    [programmes.data, codeFromUrl],
+  );
+  const effective = activeProgramme ?? fromUrl;
+
+  if (!effective || (programmes.data?.length ?? 0) === 0) return null;
+
+  const list = programmes.data ?? [];
+  const idx = list.findIndex((p) => p.id === effective.id);
+  const prev = idx > 0 ? list[idx - 1] : list[list.length - 1];
+  const next = idx < list.length - 1 ? list[idx + 1] : list[0];
+
+  function navigate(target: Programme | null) {
+    if (onSelect) {
+      onSelect(target);
+      return;
+    }
+    const params = new URLSearchParams(searchParams);
+    if (target) {
+      params.set("programme", target.code);
+    } else {
+      params.delete("programme");
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 self-start text-xs">
+      <div className="inline-flex items-center gap-1 rounded-full border border-navy/30 bg-navy/5 px-2 py-0.5 text-navy">
+        <button
+          type="button"
+          onClick={() => navigate(prev)}
+          aria-label={`Previous programme (${prev.code})`}
+          className="rounded-full p-1 hover:bg-navy/10"
+          disabled={list.length <= 1}
+        >
+          <ChevronLeft className="size-3" aria-hidden="true" />
+        </button>
+        <span className="px-1 font-medium">{effective.name}</span>
+        <button
+          type="button"
+          onClick={() => navigate(next)}
+          aria-label={`Next programme (${next.code})`}
+          className="rounded-full p-1 hover:bg-navy/10"
+          disabled={list.length <= 1}
+        >
+          <ChevronRight className="size-3" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate(null)}
+          aria-label="Clear programme filter (drill up)"
+          className="inline-flex items-center gap-0.5 rounded-full bg-navy/10 px-1.5 py-0.5 hover:bg-navy/20"
+        >
+          <X className="size-3" aria-hidden="true" /> clear
+        </button>
+      </div>
+
+      {crossLinks.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1 text-navy/70">
+          <span className="pl-1 text-navy/50">Open in:</span>
+          {crossLinks
+            .filter((link) => link.to !== currentRoute)
+            .map((link) => (
+              <Link
+                key={link.to}
+                to={`${link.to}?programme=${effective.code}`}
+                className="rounded-full border border-ice-100 bg-white px-2 py-0.5 transition hover:bg-ice-50"
+              >
+                {link.label}
+              </Link>
+            ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+

--- a/frontend/src/components/programmeCrossLinks.ts
+++ b/frontend/src/components/programmeCrossLinks.ts
@@ -1,0 +1,12 @@
+import type { CrossTabLink } from "@/components/ProgrammeFilterBar";
+
+export const PROGRAMME_CROSS_LINKS: CrossTabLink[] = [
+  { to: "/delivery", label: "Delivery" },
+  { to: "/kpi", label: "KPI Studio" },
+  { to: "/velocity", label: "Velocity" },
+  { to: "/margin", label: "Margin" },
+  { to: "/customer", label: "Customer" },
+  { to: "/ai", label: "AI Governance" },
+  { to: "/smart-ops", label: "Smart Ops" },
+  { to: "/raid", label: "Risk & Audit" },
+];

--- a/frontend/src/pages/AiGovernance.tsx
+++ b/frontend/src/pages/AiGovernance.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Bar,
@@ -16,15 +16,10 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import {
-  AlertOctagon,
-  ChevronRight,
-  Home,
-  ShieldCheck,
-  Sparkles,
-  X,
-} from "lucide-react";
+import { AlertOctagon, Home, ShieldCheck, Sparkles } from "lucide-react";
 import { Breadcrumb } from "@/components/Breadcrumb";
+import { ProgrammeFilterBar } from "@/components/ProgrammeFilterBar";
+import { PROGRAMME_CROSS_LINKS } from "@/components/programmeCrossLinks";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import {
@@ -54,7 +49,7 @@ const MATURITY_TONE: Record<string, RagBucket> = {
 };
 
 export function AiGovernance() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const programmeFilter = searchParams.get("programme");
   const programmes = useProgrammes();
 
@@ -85,11 +80,6 @@ export function AiGovernance() {
     queryFn: () => fetchAiOverrides(filteredProgramme?.id),
   });
 
-  const clearProgrammeFilter = () => {
-    const next = new URLSearchParams(searchParams);
-    next.delete("programme");
-    setSearchParams(next);
-  };
 
   const programmeByName = useMemo(
     () =>
@@ -204,38 +194,19 @@ export function AiGovernance() {
     <div className="flex flex-col gap-6">
       <Breadcrumb items={breadcrumbItems} />
 
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold text-navy">AI Governance</h1>
-          <p className="mt-1 text-sm text-navy/70">
-            Are AI tools trustworthy, compliant, and productive? 6-factor
-            composite trust score per programme, plus the productivity-tax
-            with/without AI comparison.
-          </p>
-        </div>
-        {filteredProgramme ? (
-          <Link
-            to={`/delivery?programme=${filteredProgramme.code}`}
-            className="btn-ghost"
-          >
-            View Delivery Health <ChevronRight className="size-3" />
-          </Link>
-        ) : null}
+      <div>
+        <h1 className="text-2xl font-semibold text-navy">AI Governance</h1>
+        <p className="mt-1 text-sm text-navy/70">
+          Are AI tools trustworthy, compliant, and productive? 6-factor
+          composite trust score per programme, plus the productivity-tax
+          with/without AI comparison.
+        </p>
       </div>
 
-      {filteredProgramme ? (
-        <div className="inline-flex items-center gap-2 self-start rounded-full border border-navy/30 bg-navy/5 px-3 py-1 text-xs text-navy">
-          Filtered to <strong>{filteredProgramme.name}</strong>
-          <button
-            type="button"
-            onClick={clearProgrammeFilter}
-            className="inline-flex items-center rounded-full bg-navy/10 px-1.5 py-0.5 transition hover:bg-navy/20"
-            aria-label="Clear programme filter (drill up)"
-          >
-            <X className="size-3" /> clear
-          </button>
-        </div>
-      ) : null}
+      <ProgrammeFilterBar
+        currentRoute="/ai"
+        crossLinks={PROGRAMME_CROSS_LINKS}
+      />
 
       <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
         <Stat

--- a/frontend/src/pages/CustomerIntelligence.tsx
+++ b/frontend/src/pages/CustomerIntelligence.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   CartesianGrid,
@@ -16,8 +16,10 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { AlertOctagon, ChevronRight, Home, Sparkles, X } from "lucide-react";
+import { AlertOctagon, ChevronDown, ChevronUp, Home, Sparkles } from "lucide-react";
 import { Breadcrumb } from "@/components/Breadcrumb";
+import { ProgrammeFilterBar } from "@/components/ProgrammeFilterBar";
+import { PROGRAMME_CROSS_LINKS } from "@/components/programmeCrossLinks";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import {
@@ -59,6 +61,8 @@ export function CustomerIntelligence() {
   const currency = useCurrency();
 
   const [activeProgrammeId, setActiveProgrammeId] = useState<number | null>(null);
+  const [expandedAction, setExpandedAction] = useState<number | null>(null);
+  const [expandedIncident, setExpandedIncident] = useState<number | null>(null);
 
   const filteredProgramme = useMemo(
     () => programmes.data?.find((p) => p.code === programmeFilter) ?? null,
@@ -112,10 +116,21 @@ export function CustomerIntelligence() {
     enabled: activeProgrammeId !== null,
   });
 
-  const clearProgrammeFilter = () => {
-    const next = new URLSearchParams(searchParams);
-    next.delete("programme");
-    setSearchParams(next);
+  const handleProgrammeChange = (next: { id: number } | null) => {
+    setActiveProgrammeId(next?.id ?? null);
+    const params = new URLSearchParams(searchParams);
+    if (next) {
+      const code =
+        programmes.data?.find((p) => p.id === next.id)?.code ?? "";
+      if (code) {
+        params.set("programme", code);
+      } else {
+        params.delete("programme");
+      }
+    } else {
+      params.delete("programme");
+    }
+    setSearchParams(params);
   };
 
   const latest = useMemo(() => {
@@ -173,37 +188,20 @@ export function CustomerIntelligence() {
     <div className="flex flex-col gap-6">
       <Breadcrumb items={breadcrumbItems} />
 
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold text-navy">Customer Intelligence</h1>
-          <p className="mt-1 text-sm text-navy/70">
-            Will this customer renew? Where is their expectation gap widest?
-            What escalations are open?
-          </p>
-        </div>
-        {activeProgramme ? (
-          <Link
-            to={`/delivery?programme=${activeProgramme.code}`}
-            className="btn-ghost"
-          >
-            View Delivery Health <ChevronRight className="size-3" />
-          </Link>
-        ) : null}
+      <div>
+        <h1 className="text-2xl font-semibold text-navy">Customer Intelligence</h1>
+        <p className="mt-1 text-sm text-navy/70">
+          Will this customer renew? Where is their expectation gap widest?
+          What escalations are open?
+        </p>
       </div>
 
-      {filteredProgramme ? (
-        <div className="inline-flex items-center gap-2 self-start rounded-full border border-navy/30 bg-navy/5 px-3 py-1 text-xs text-navy">
-          Filtered to <strong>{filteredProgramme.name}</strong>
-          <button
-            type="button"
-            onClick={clearProgrammeFilter}
-            className="inline-flex items-center rounded-full bg-navy/10 px-1.5 py-0.5 transition hover:bg-navy/20"
-            aria-label="Clear programme filter (drill up)"
-          >
-            <X className="size-3" /> clear
-          </button>
-        </div>
-      ) : null}
+      <ProgrammeFilterBar
+        currentRoute="/customer"
+        activeProgramme={activeProgramme}
+        onSelect={(next) => handleProgrammeChange(next)}
+        crossLinks={PROGRAMME_CROSS_LINKS}
+      />
 
       {!filteredProgramme ? (
         <Card>
@@ -413,42 +411,71 @@ export function CustomerIntelligence() {
           <p className="text-sm text-navy/60">No steering-committee actions recorded.</p>
         ) : (
           <ul className="flex flex-col gap-2 text-sm">
-            {(actions.data ?? []).map((a) => (
-              <li
-                key={a.id}
-                className="flex items-center justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2"
-              >
-                <div>
-                  <p className="font-medium">{a.description}</p>
-                  <p className="text-xs text-navy/60">
-                    Meeting {formatDate(a.meeting_date)}
-                    {a.owner ? ` · ${a.owner}` : ""}
-                    {a.due_date ? ` · due ${formatDate(a.due_date)}` : ""}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  {a.escalated ? (
-                    <Badge tone="red">
-                      <AlertOctagon className="size-3" /> escalated
-                    </Badge>
-                  ) : null}
-                  <Badge tone={a.priority === "P1" ? "red" : a.priority === "P2" ? "amber" : "neutral"}>
-                    {a.priority ?? "—"}
-                  </Badge>
-                  <Badge
-                    tone={
-                      a.status === "Closed"
-                        ? "green"
-                        : a.status === "Open"
-                          ? "amber"
-                          : "neutral"
-                    }
+            {(actions.data ?? []).map((a) => {
+              const isOpen = expandedAction === a.id;
+              return (
+                <li
+                  key={a.id}
+                  className="rounded border border-ice-100 bg-white"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setExpandedAction(isOpen ? null : a.id)}
+                    aria-expanded={isOpen}
+                    className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition hover:bg-ice-50"
                   >
-                    {a.status}
-                  </Badge>
-                </div>
-              </li>
-            ))}
+                    <div>
+                      <p className="font-medium">{a.description}</p>
+                      <p className="text-xs text-navy/60">
+                        Meeting {formatDate(a.meeting_date)}
+                        {a.owner ? ` · ${a.owner}` : ""}
+                        {a.due_date ? ` · due ${formatDate(a.due_date)}` : ""}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {a.escalated ? (
+                        <Badge tone="red">
+                          <AlertOctagon className="size-3" /> escalated
+                        </Badge>
+                      ) : null}
+                      <Badge tone={a.priority === "P1" ? "red" : a.priority === "P2" ? "amber" : "neutral"}>
+                        {a.priority ?? "—"}
+                      </Badge>
+                      <Badge
+                        tone={
+                          a.status === "Closed"
+                            ? "green"
+                            : a.status === "Open"
+                              ? "amber"
+                              : "neutral"
+                        }
+                      >
+                        {a.status}
+                      </Badge>
+                      {isOpen ? (
+                        <ChevronUp className="size-4 text-navy/40" aria-hidden="true" />
+                      ) : (
+                        <ChevronDown className="size-4 text-navy/40" aria-hidden="true" />
+                      )}
+                    </div>
+                  </button>
+                  {isOpen ? (
+                    <dl className="grid grid-cols-2 gap-3 px-3 pb-3 text-xs md:grid-cols-4">
+                      <Detail label="Priority" value={a.priority ?? "—"} />
+                      <Detail label="Owner" value={a.owner ?? "—"} />
+                      <Detail label="Due" value={formatDate(a.due_date)} />
+                      <Detail label="Closed" value={formatDate(a.closed_date)} />
+                      {a.resolution_notes ? (
+                        <div className="md:col-span-4">
+                          <span className="kpi-label">Resolution</span>
+                          <p className="text-navy/80 italic">{a.resolution_notes}</p>
+                        </div>
+                      ) : null}
+                    </dl>
+                  ) : null}
+                </li>
+              );
+            })}
           </ul>
         )}
       </Card>
@@ -477,50 +504,105 @@ export function CustomerIntelligence() {
                 </tr>
               </thead>
               <tbody>
-                {(incidents.data ?? []).map((i) => (
-                  <tr key={i.id} className="border-t border-ice-100">
-                    <td className="py-2 font-mono text-xs">{i.incident_id ?? "—"}</td>
-                    <td>
-                      <Badge
-                        tone={
-                          i.priority === "P1"
-                            ? "red"
-                            : i.priority === "P2"
-                              ? "amber"
-                              : "neutral"
-                        }
+                {(incidents.data ?? []).map((i) => {
+                  const isOpen = expandedIncident === i.id;
+                  return (
+                    <Fragment key={i.id}>
+                      <tr
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => setExpandedIncident(isOpen ? null : i.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            setExpandedIncident(isOpen ? null : i.id);
+                          }
+                        }}
+                        className="cursor-pointer border-t border-ice-100 transition hover:bg-ice-50"
+                        aria-expanded={isOpen}
                       >
-                        {i.priority}
-                      </Badge>
-                    </td>
-                    <td>
-                      <p className="font-medium">{i.summary ?? "—"}</p>
-                      {i.root_cause ? (
-                        <p className="text-xs text-navy/60">{i.root_cause}</p>
+                        <td className="py-2 font-mono text-xs">{i.incident_id ?? "—"}</td>
+                        <td>
+                          <Badge
+                            tone={
+                              i.priority === "P1"
+                                ? "red"
+                                : i.priority === "P2"
+                                  ? "amber"
+                                  : "neutral"
+                            }
+                          >
+                            {i.priority}
+                          </Badge>
+                        </td>
+                        <td>
+                          <p className="font-medium">{i.summary ?? "—"}</p>
+                          {i.root_cause ? (
+                            <p className="text-xs text-navy/60">{i.root_cause}</p>
+                          ) : null}
+                        </td>
+                        <td className="text-right font-mono">
+                          {i.response_time_minutes === null
+                            ? "—"
+                            : `${i.response_time_minutes.toFixed(0)}m`}
+                        </td>
+                        <td className="text-right font-mono">
+                          {i.resolution_time_minutes === null
+                            ? "—"
+                            : `${(i.resolution_time_minutes / 60).toFixed(1)}h`}
+                        </td>
+                        <td className="text-right font-mono">
+                          {currency.format(i.penalty_amount, sourceCurrency)}
+                        </td>
+                        <td className="text-right">
+                          {i.sla_breached ? (
+                            <Badge tone="red">breach</Badge>
+                          ) : (
+                            <Badge tone="green">met</Badge>
+                          )}
+                        </td>
+                      </tr>
+                      {isOpen ? (
+                        <tr className="bg-ice-50/40">
+                          <td colSpan={7} className="px-3 py-3 text-xs">
+                            <dl className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                              <Detail
+                                label="Reported"
+                                value={new Date(i.reported_at).toLocaleString("en-GB")}
+                              />
+                              <Detail
+                                label="Responded"
+                                value={
+                                  i.responded_at
+                                    ? new Date(i.responded_at).toLocaleString("en-GB")
+                                    : "—"
+                                }
+                              />
+                              <Detail
+                                label="Resolved"
+                                value={
+                                  i.resolved_at
+                                    ? new Date(i.resolved_at).toLocaleString("en-GB")
+                                    : "—"
+                                }
+                              />
+                              <Detail
+                                label="Penalty"
+                                value={currency.format(i.penalty_amount, sourceCurrency)}
+                              />
+                              {i.root_cause ? (
+                                <div className="md:col-span-4">
+                                  <span className="kpi-label">Root cause</span>
+                                  <p className="italic text-navy/80">{i.root_cause}</p>
+                                </div>
+                              ) : null}
+                            </dl>
+                          </td>
+                        </tr>
                       ) : null}
-                    </td>
-                    <td className="text-right font-mono">
-                      {i.response_time_minutes === null
-                        ? "—"
-                        : `${i.response_time_minutes.toFixed(0)}m`}
-                    </td>
-                    <td className="text-right font-mono">
-                      {i.resolution_time_minutes === null
-                        ? "—"
-                        : `${(i.resolution_time_minutes / 60).toFixed(1)}h`}
-                    </td>
-                    <td className="text-right font-mono">
-                      {currency.format(i.penalty_amount, sourceCurrency)}
-                    </td>
-                    <td className="text-right">
-                      {i.sla_breached ? (
-                        <Badge tone="red">breach</Badge>
-                      ) : (
-                        <Badge tone="green">met</Badge>
-                      )}
-                    </td>
-                  </tr>
-                ))}
+                    </Fragment>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -549,6 +631,15 @@ function Stat({
         {tone !== "neutral" ? <Badge tone={tone}>·</Badge> : null}
       </div>
       {sub ? <p className="text-xs text-navy/60">{sub}</p> : null}
+    </div>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="kpi-label">{label}</span>
+      <span className="font-mono text-navy">{value}</span>
     </div>
   );
 }

--- a/frontend/src/pages/MarginEvm.tsx
+++ b/frontend/src/pages/MarginEvm.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Fragment, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Bar,
@@ -12,8 +12,10 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { ChevronRight, Home, X } from "lucide-react";
+import { ChevronDown, ChevronUp, Home } from "lucide-react";
 import { Breadcrumb } from "@/components/Breadcrumb";
+import { ProgrammeFilterBar } from "@/components/ProgrammeFilterBar";
+import { PROGRAMME_CROSS_LINKS } from "@/components/programmeCrossLinks";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import {
@@ -27,10 +29,11 @@ import { useCurrency } from "@/hooks/useCurrency";
 import { formatPct } from "@/lib/format";
 
 export function MarginEvm() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const programmeFilter = searchParams.get("programme");
   const programmes = useProgrammes();
   const currency = useCurrency();
+  const [expandedCr, setExpandedCr] = useState<number | null>(null);
 
   const filteredProgramme = useMemo(
     () => programmes.data?.find((p) => p.code === programmeFilter) ?? null,
@@ -55,11 +58,6 @@ export function MarginEvm() {
     queryFn: () => fetchChangeRequests(filteredProgramme?.id),
   });
 
-  const clearProgrammeFilter = () => {
-    const next = new URLSearchParams(searchParams);
-    next.delete("programme");
-    setSearchParams(next);
-  };
 
   // Latest commercial per programme — for the 4-layer margin waterfall.
   const latestCommercial = useMemo(() => {
@@ -130,37 +128,18 @@ export function MarginEvm() {
     <div className="flex flex-col gap-6">
       <Breadcrumb items={breadcrumbItems} />
 
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold text-navy">Margin & EVM</h1>
-          <p className="mt-1 text-sm text-navy/70">
-            Where is margin leaking and by how much? 4-layer margin waterfall
-            plus the 7 delivery-loss categories from ARCHITECTURE.md §6.
-          </p>
-        </div>
-        {filteredProgramme ? (
-          <Link
-            to={`/delivery?programme=${filteredProgramme.code}`}
-            className="btn-ghost"
-          >
-            View Delivery Health <ChevronRight className="size-3" />
-          </Link>
-        ) : null}
+      <div>
+        <h1 className="text-2xl font-semibold text-navy">Margin & EVM</h1>
+        <p className="mt-1 text-sm text-navy/70">
+          Where is margin leaking and by how much? 4-layer margin waterfall
+          plus the 7 delivery-loss categories from ARCHITECTURE.md §6.
+        </p>
       </div>
 
-      {filteredProgramme ? (
-        <div className="inline-flex items-center gap-2 self-start rounded-full border border-navy/30 bg-navy/5 px-3 py-1 text-xs text-navy">
-          Filtered to <strong>{filteredProgramme.name}</strong>
-          <button
-            type="button"
-            onClick={clearProgrammeFilter}
-            className="inline-flex items-center rounded-full bg-navy/10 px-1.5 py-0.5 transition hover:bg-navy/20"
-            aria-label="Clear programme filter (drill up)"
-          >
-            <X className="size-3" /> clear
-          </button>
-        </div>
-      ) : null}
+      <ProgrammeFilterBar
+        currentRoute="/margin"
+        crossLinks={PROGRAMME_CROSS_LINKS}
+      />
 
       <Card>
         <CardHeader
@@ -325,54 +304,109 @@ export function MarginEvm() {
                   <th className="text-right">Value</th>
                   <th className="text-right">Margin Δ</th>
                   <th>Status</th>
+                  <th aria-hidden="true" />
                 </tr>
               </thead>
               <tbody>
-                {(changeRequests.data ?? []).map((cr) => (
-                  <tr key={cr.id} className="border-t border-ice-100">
-                    <td className="py-2 font-mono text-xs">{cr.cr_date}</td>
-                    <td>
-                      <p className="font-medium">{cr.cr_description ?? "—"}</p>
-                      {cr.is_billable === false ? (
-                        <span className="text-xs text-danger-600">non-billable</span>
+                {(changeRequests.data ?? []).map((cr) => {
+                  const isOpen = expandedCr === cr.id;
+                  const cost =
+                    currency.format(cr.processing_cost, sourceCurrency);
+                  return (
+                    <Fragment key={cr.id}>
+                      <tr
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => setExpandedCr(isOpen ? null : cr.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            setExpandedCr(isOpen ? null : cr.id);
+                          }
+                        }}
+                        className="cursor-pointer border-t border-ice-100 transition hover:bg-ice-50"
+                        aria-expanded={isOpen}
+                      >
+                        <td className="py-2 font-mono text-xs">{cr.cr_date}</td>
+                        <td>
+                          <p className="font-medium">{cr.cr_description ?? "—"}</p>
+                          {cr.is_billable === false ? (
+                            <span className="text-xs text-danger-600">non-billable</span>
+                          ) : null}
+                        </td>
+                        <td className="text-right font-mono">
+                          {cr.effort_hours ?? "—"}
+                        </td>
+                        <td className="text-right font-mono">
+                          {currency.format(cr.cr_value, sourceCurrency)}
+                        </td>
+                        <td className="text-right font-mono">
+                          <Badge
+                            tone={
+                              cr.margin_impact === null
+                                ? "neutral"
+                                : cr.margin_impact >= 0
+                                  ? "green"
+                                  : cr.margin_impact >= -1
+                                    ? "amber"
+                                    : "red"
+                            }
+                          >
+                            {formatPct(cr.margin_impact === null ? null : cr.margin_impact / 100)}
+                          </Badge>
+                        </td>
+                        <td>
+                          <Badge
+                            tone={
+                              cr.status === "Approved"
+                                ? "green"
+                                : cr.status === "Pending" || cr.status === "In Review"
+                                  ? "amber"
+                                  : "neutral"
+                            }
+                          >
+                            {cr.status ?? "—"}
+                          </Badge>
+                        </td>
+                        <td className="pr-2 text-right text-navy/40">
+                          {isOpen ? (
+                            <ChevronUp className="inline size-4" aria-hidden="true" />
+                          ) : (
+                            <ChevronDown className="inline size-4" aria-hidden="true" />
+                          )}
+                        </td>
+                      </tr>
+                      {isOpen ? (
+                        <tr className="bg-ice-50/40">
+                          <td colSpan={7} className="px-3 py-3 text-xs text-navy/80">
+                            <dl className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                              <Detail label="Processing cost" value={cost} />
+                              <Detail
+                                label="Net impact"
+                                value={currency.format(
+                                  (cr.cr_value ?? 0) - (cr.processing_cost ?? 0),
+                                  sourceCurrency,
+                                )}
+                              />
+                              <Detail
+                                label="Billable"
+                                value={cr.is_billable === false ? "No" : "Yes"}
+                              />
+                              <Detail
+                                label="Programme"
+                                value={
+                                  programmes.data?.find(
+                                    (p) => p.id === cr.program_id,
+                                  )?.code ?? "—"
+                                }
+                              />
+                            </dl>
+                          </td>
+                        </tr>
                       ) : null}
-                    </td>
-                    <td className="text-right font-mono">
-                      {cr.effort_hours ?? "—"}
-                    </td>
-                    <td className="text-right font-mono">
-                      {currency.format(cr.cr_value, sourceCurrency)}
-                    </td>
-                    <td className="text-right font-mono">
-                      <Badge
-                        tone={
-                          cr.margin_impact === null
-                            ? "neutral"
-                            : cr.margin_impact >= 0
-                              ? "green"
-                              : cr.margin_impact >= -1
-                                ? "amber"
-                                : "red"
-                        }
-                      >
-                        {formatPct(cr.margin_impact === null ? null : cr.margin_impact / 100)}
-                      </Badge>
-                    </td>
-                    <td>
-                      <Badge
-                        tone={
-                          cr.status === "Approved"
-                            ? "green"
-                            : cr.status === "Pending" || cr.status === "In Review"
-                              ? "amber"
-                              : "neutral"
-                        }
-                      >
-                        {cr.status ?? "—"}
-                      </Badge>
-                    </td>
-                  </tr>
-                ))}
+                    </Fragment>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -381,3 +415,13 @@ export function MarginEvm() {
     </div>
   );
 }
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="kpi-label">{label}</span>
+      <span className="font-mono text-navy">{value}</span>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/RiskAudit.tsx
+++ b/frontend/src/pages/RiskAudit.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Bar,
@@ -10,8 +11,17 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { ClipboardList, FileText, Home, ShieldCheck } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  ClipboardList,
+  FileText,
+  Home,
+  ShieldCheck,
+} from "lucide-react";
 import { Breadcrumb } from "@/components/Breadcrumb";
+import { ProgrammeFilterBar } from "@/components/ProgrammeFilterBar";
+import { PROGRAMME_CROSS_LINKS } from "@/components/programmeCrossLinks";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import {
@@ -31,9 +41,17 @@ function riskSeverityTone(severity: string | null): RagBucket {
 }
 
 export function RiskAudit() {
+  const [searchParams] = useSearchParams();
+  const programmeFilter = searchParams.get("programme");
   const [tableFilter, setTableFilter] = useState<string | null>(null);
+  const [expandedRisk, setExpandedRisk] = useState<number | null>(null);
   const programmes = useProgrammes();
   const currency = useCurrency();
+
+  const filteredProgramme = useMemo(
+    () => programmes.data?.find((p) => p.code === programmeFilter) ?? null,
+    [programmes.data, programmeFilter],
+  );
 
   const risks = useQuery({
     queryKey: ["risks", "all", 50],
@@ -89,12 +107,19 @@ export function RiskAudit() {
     }));
   }, [governance.data]);
 
+  const visibleRisks = useMemo(() => {
+    const all = risks.data ?? [];
+    if (!filteredProgramme) return all;
+    return all.filter((r) => r.program_id === filteredProgramme.id);
+  }, [risks.data, filteredProgramme]);
+
   return (
     <div className="flex flex-col gap-6">
       <Breadcrumb
         items={[
           { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
-          { label: "Risk & Audit" },
+          { label: "Risk & Audit", to: filteredProgramme ? "/raid" : undefined },
+          ...(filteredProgramme ? [{ label: filteredProgramme.name }] : []),
         ]}
       />
 
@@ -104,10 +129,14 @@ export function RiskAudit() {
           If an auditor walked in today, could we demonstrate governance?
           RAID register, compliance scorecard, data-change trail.
         </p>
+        <ProgrammeFilterBar
+          currentRoute="/raid"
+          crossLinks={PROGRAMME_CROSS_LINKS}
+        />
       </div>
 
       <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
-        <Stat label="Open risks" value={`${risks.data?.length ?? 0}`} />
+        <Stat label="Open risks" value={`${visibleRisks.length}`} />
         <Stat
           label="Controls tracked"
           value={`${governance.data?.length ?? 0}`}
@@ -121,7 +150,7 @@ export function RiskAudit() {
         <Stat
           label="Risk-weighted exposure"
           value={currency.format(
-            (risks.data ?? []).reduce(
+            visibleRisks.reduce(
               (sum, r) => sum + (r.impact ?? 0) * (r.probability ?? 0),
               0,
             ),
@@ -147,30 +176,103 @@ export function RiskAudit() {
                 <th className="text-right">Probability</th>
                 <th className="text-right">Impact</th>
                 <th>Owner</th>
-                <th>Mitigation</th>
+                <th aria-hidden="true" />
               </tr>
             </thead>
             <tbody>
-              {(risks.data ?? []).map((r) => {
+              {visibleRisks.map((r) => {
                 const programmeInfo =
                   r.program_id !== null ? programmeByName.get(r.program_id) : null;
+                const isOpen = expandedRisk === r.id;
                 return (
-                  <tr key={r.id} className="border-t border-ice-100 align-top">
-                    <td className="py-2 font-medium">{r.title}</td>
-                    <td>{programmeInfo?.code ?? "—"}</td>
-                    <td>{r.category ?? "—"}</td>
-                    <td>
-                      <Badge tone={riskSeverityTone(r.severity)}>{r.severity ?? "—"}</Badge>
-                    </td>
-                    <td className="text-right font-mono">
-                      {r.probability === null ? "—" : formatPct(r.probability)}
-                    </td>
-                    <td className="text-right font-mono">
-                      {currency.format(r.impact, programmeInfo?.currency_code ?? "INR")}
-                    </td>
-                    <td>{r.owner ?? "—"}</td>
-                    <td className="text-xs text-navy/70">{r.mitigation_plan ?? "—"}</td>
-                  </tr>
+                  <Fragment key={r.id}>
+                    <tr
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setExpandedRisk(isOpen ? null : r.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          setExpandedRisk(isOpen ? null : r.id);
+                        }
+                      }}
+                      className="cursor-pointer border-t border-ice-100 transition hover:bg-ice-50"
+                      aria-expanded={isOpen}
+                    >
+                      <td className="py-2 font-medium">{r.title}</td>
+                      <td>{programmeInfo?.code ?? "—"}</td>
+                      <td>{r.category ?? "—"}</td>
+                      <td>
+                        <Badge tone={riskSeverityTone(r.severity)}>{r.severity ?? "—"}</Badge>
+                      </td>
+                      <td className="text-right font-mono">
+                        {r.probability === null ? "—" : formatPct(r.probability)}
+                      </td>
+                      <td className="text-right font-mono">
+                        {currency.format(r.impact, programmeInfo?.currency_code ?? "INR")}
+                      </td>
+                      <td>{r.owner ?? "—"}</td>
+                      <td className="pr-2 text-right text-navy/40">
+                        {isOpen ? (
+                          <ChevronUp className="inline size-4" aria-hidden="true" />
+                        ) : (
+                          <ChevronDown className="inline size-4" aria-hidden="true" />
+                        )}
+                      </td>
+                    </tr>
+                    {isOpen ? (
+                      <tr className="bg-ice-50/40">
+                        <td colSpan={8} className="px-3 py-3 text-xs">
+                          <dl className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                            <div className="md:col-span-2">
+                              <span className="kpi-label">Description</span>
+                              <p className="text-navy/80">{r.description ?? "—"}</p>
+                            </div>
+                            <div className="md:col-span-2">
+                              <span className="kpi-label">Mitigation plan</span>
+                              <p className="italic text-navy/80">
+                                {r.mitigation_plan ?? "—"}
+                              </p>
+                            </div>
+                            <Detail
+                              label="Expected loss (impact × prob.)"
+                              value={currency.format(
+                                (r.impact ?? 0) * (r.probability ?? 0),
+                                programmeInfo?.currency_code ?? "INR",
+                              )}
+                            />
+                            <Detail
+                              label="Status"
+                              value={r.status}
+                            />
+                          </dl>
+                          {programmeInfo ? (
+                            <div className="mt-3 flex flex-wrap gap-2 text-xs text-navy/70">
+                              <span className="text-navy/50">Open programme in:</span>
+                              <Link
+                                to={`/delivery?programme=${programmeInfo.code}`}
+                                className="rounded-full border border-ice-100 bg-white px-2 py-0.5 hover:bg-ice-50"
+                              >
+                                Delivery
+                              </Link>
+                              <Link
+                                to={`/kpi?programme=${programmeInfo.code}`}
+                                className="rounded-full border border-ice-100 bg-white px-2 py-0.5 hover:bg-ice-50"
+                              >
+                                KPIs
+                              </Link>
+                              <Link
+                                to={`/customer?programme=${programmeInfo.code}`}
+                                className="rounded-full border border-ice-100 bg-white px-2 py-0.5 hover:bg-ice-50"
+                              >
+                                Customer
+                              </Link>
+                            </div>
+                          ) : null}
+                        </td>
+                      </tr>
+                    ) : null}
+                  </Fragment>
                 );
               })}
             </tbody>
@@ -401,3 +503,13 @@ function Stat({
     </div>
   );
 }
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="kpi-label">{label}</span>
+      <span className="font-mono text-sm text-navy">{value}</span>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/SmartOps.tsx
+++ b/frontend/src/pages/SmartOps.tsx
@@ -1,15 +1,27 @@
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { AlertOctagon, CheckCircle2, Clock, Home, Users } from "lucide-react";
+import {
+  AlertOctagon,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  Home,
+  Users,
+} from "lucide-react";
 import { Breadcrumb } from "@/components/Breadcrumb";
+import { ProgrammeFilterBar } from "@/components/ProgrammeFilterBar";
+import { PROGRAMME_CROSS_LINKS } from "@/components/programmeCrossLinks";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import {
   fetchResources,
   fetchScenarios,
-  type ScenarioExecution,
   type ResourceRow,
+  type ScenarioExecution,
 } from "@/lib/api";
+import { useProgrammes } from "@/hooks/usePortfolio";
 import { useCurrency } from "@/hooks/useCurrency";
 import { formatPct, type RagBucket } from "@/lib/format";
 
@@ -22,7 +34,18 @@ const STATUS_TONE: Record<string, RagBucket | "neutral"> = {
 };
 
 export function SmartOps() {
+  const [searchParams] = useSearchParams();
+  const programmeFilter = searchParams.get("programme");
+  const programmes = useProgrammes();
   const [filter, setFilter] = useState<string | null>(null);
+  const [expandedScenario, setExpandedScenario] = useState<number | null>(null);
+  const [expandedResource, setExpandedResource] = useState<number | null>(null);
+
+  const filteredProgramme = useMemo(
+    () => programmes.data?.find((p) => p.code === programmeFilter) ?? null,
+    [programmes.data, programmeFilter],
+  );
+
   const scenarios = useQuery({
     queryKey: ["scenarios", filter],
     queryFn: () => fetchScenarios(filter ?? undefined),
@@ -33,17 +56,33 @@ export function SmartOps() {
   });
   const currency = useCurrency();
 
-  const activeCount = (scenarios.data ?? []).filter(
-    (s) => s.status === "Active",
-  ).length;
-  const mitigatingCount = (scenarios.data ?? []).filter(
+  // Filter scenarios client-side to the programme when ?programme= is set —
+  // scenario details contain a JSON string with "program":"CODE" inside.
+  const visibleScenarios = useMemo(() => {
+    const all = scenarios.data ?? [];
+    if (!filteredProgramme) return all;
+    return all.filter((s) =>
+      (s.details ?? "").includes(`"${filteredProgramme.code}"`),
+    );
+  }, [scenarios.data, filteredProgramme]);
+
+  const visibleResources = useMemo(() => {
+    const all = resources.data ?? [];
+    if (!filteredProgramme) return all;
+    return all.filter(
+      (r) => r.current_program_id === filteredProgramme.id,
+    );
+  }, [resources.data, filteredProgramme]);
+
+  const activeCount = visibleScenarios.filter((s) => s.status === "Active").length;
+  const mitigatingCount = visibleScenarios.filter(
     (s) => s.status === "Mitigating",
   ).length;
-  const totalFinancialImpact = (scenarios.data ?? []).reduce(
+  const totalFinancialImpact = visibleScenarios.reduce(
     (sum, s) => sum + (s.financial_impact ?? 0),
     0,
   );
-  const bench = (resources.data ?? []).filter((r) => r.status === "Bench");
+  const bench = visibleResources.filter((r) => r.status === "Bench");
   const benchCost = bench.reduce(
     (sum, r) => sum + ((r.loaded_cost_annual ?? 0) / 365) * r.bench_days,
     0,
@@ -62,7 +101,8 @@ export function SmartOps() {
       <Breadcrumb
         items={[
           { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
-          { label: "Smart Ops" },
+          { label: "Smart Ops", to: filteredProgramme ? "/smart-ops" : undefined },
+          ...(filteredProgramme ? [{ label: filteredProgramme.name }] : []),
         ]}
       />
 
@@ -75,16 +115,21 @@ export function SmartOps() {
         </p>
       </div>
 
+      <ProgrammeFilterBar
+        currentRoute="/smart-ops"
+        crossLinks={PROGRAMME_CROSS_LINKS}
+      />
+
       <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
         <Stat label="Active alerts" value={`${activeCount}`} tone={activeCount === 0 ? "green" : "red"} />
         <Stat label="Mitigating" value={`${mitigatingCount}`} tone={mitigatingCount > 0 ? "amber" : "green"} />
         <Stat
           label="Financial impact"
           value={currency.format(totalFinancialImpact, "INR")}
-          sub="Sum across active + mitigating alerts"
+          sub="Sum across visible alerts"
         />
         <Stat
-          label="Bench cost (YTD-ish)"
+          label="Bench cost"
           value={currency.format(benchCost, "INR")}
           sub={`${bench.length} FTE on bench`}
         />
@@ -93,7 +138,7 @@ export function SmartOps() {
       <Card>
         <CardHeader
           title="Scenario alerts"
-          subtitle="Filter by status"
+          subtitle={`${visibleScenarios.length} shown · click any row to expand`}
           action={
             <div className="flex flex-wrap gap-1">
               <button
@@ -120,12 +165,20 @@ export function SmartOps() {
             </div>
           }
         />
-        {(scenarios.data ?? []).length === 0 ? (
-          <p className="text-sm text-navy/60">No scenario executions match the filter.</p>
+        {visibleScenarios.length === 0 ? (
+          <p className="text-sm text-navy/60">No scenario executions match the current scope.</p>
         ) : (
           <ul className="flex flex-col gap-2">
-            {(scenarios.data ?? []).map((s) => (
-              <ScenarioRow key={s.id} scenario={s} sourceCurrency="INR" />
+            {visibleScenarios.map((s) => (
+              <ScenarioRow
+                key={s.id}
+                scenario={s}
+                isOpen={expandedScenario === s.id}
+                onToggle={() =>
+                  setExpandedScenario(expandedScenario === s.id ? null : s.id)
+                }
+                sourceCurrency="INR"
+              />
             ))}
           </ul>
         )}
@@ -134,7 +187,7 @@ export function SmartOps() {
       <Card>
         <CardHeader
           title="Resource pool"
-          subtitle={`${resources.data?.length ?? 0} people · ${bench.length} on bench`}
+          subtitle={`${visibleResources.length} people · ${bench.length} on bench`}
           action={<Users className="size-4 text-navy/60" aria-hidden="true" />}
         />
         <div className="overflow-x-auto">
@@ -148,11 +201,20 @@ export function SmartOps() {
                 <th className="text-right">Bench days</th>
                 <th className="text-right">Loaded cost/yr</th>
                 <th>Status</th>
+                <th aria-hidden="true" />
               </tr>
             </thead>
             <tbody>
-              {(resources.data ?? []).map((r) => (
-                <ResourceRowView key={r.id} row={r} currencyFormat={currency.format} />
+              {visibleResources.map((r) => (
+                <ResourceRowView
+                  key={r.id}
+                  row={r}
+                  isOpen={expandedResource === r.id}
+                  onToggle={() =>
+                    setExpandedResource(expandedResource === r.id ? null : r.id)
+                  }
+                  currencyFormat={currency.format}
+                />
               ))}
             </tbody>
           </table>
@@ -165,77 +227,177 @@ export function SmartOps() {
 function ScenarioRow({
   scenario,
   sourceCurrency,
+  isOpen,
+  onToggle,
 }: {
   scenario: ScenarioExecution;
   sourceCurrency: string;
+  isOpen: boolean;
+  onToggle: () => void;
 }) {
   const currency = useCurrency();
   const tone = STATUS_TONE[scenario.status ?? ""] ?? "neutral";
+  let parsedDetails: Record<string, unknown> | null = null;
+  try {
+    if (scenario.details) {
+      parsedDetails = JSON.parse(scenario.details) as Record<string, unknown>;
+    }
+  } catch {
+    parsedDetails = null;
+  }
   return (
-    <li className="flex items-start justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2">
-      <div className="flex flex-1 flex-col gap-1">
-        <div className="flex items-center gap-2">
-          <AlertOctagon
-            className={`size-4 ${
-              scenario.status === "Active" ? "text-danger-600" : "text-amber-500"
-            }`}
-            aria-hidden="true"
-          />
-          <span className="font-semibold">{scenario.scenario_name}</span>
-          <Badge tone={tone}>{scenario.status ?? "—"}</Badge>
+    <li className="rounded border border-ice-100 bg-white">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        className="flex w-full items-start justify-between gap-3 px-3 py-2 text-left transition hover:bg-ice-50"
+      >
+        <div className="flex flex-1 flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <AlertOctagon
+              className={`size-4 ${
+                scenario.status === "Active" ? "text-danger-600" : "text-amber-500"
+              }`}
+              aria-hidden="true"
+            />
+            <span className="font-semibold">{scenario.scenario_name}</span>
+            <Badge tone={tone}>{scenario.status ?? "—"}</Badge>
+          </div>
+          <p className="text-xs text-navy/60">
+            <Clock className="inline size-3" aria-hidden="true" />{" "}
+            {scenario.execution_date
+              ? new Date(scenario.execution_date).toLocaleString("en-GB")
+              : "—"}
+            {" · "}
+            triggered by {scenario.triggered_by ?? "—"}
+          </p>
         </div>
-        {scenario.details ? (
-          <p className="rounded bg-ice-50 px-2 py-1 font-mono text-xs">{scenario.details}</p>
-        ) : null}
-        {scenario.outcome_notes ? (
-          <p className="text-xs italic text-navy/70">Action: {scenario.outcome_notes}</p>
-        ) : null}
-        <p className="text-xs text-navy/60">
-          <Clock className="inline size-3" aria-hidden="true" />{" "}
-          {scenario.execution_date
-            ? new Date(scenario.execution_date).toLocaleString("en-GB")
-            : "—"}
-          {" · "}
-          triggered by {scenario.triggered_by ?? "—"}
-        </p>
-      </div>
-      <div className="text-right font-mono text-sm">
-        {currency.format(scenario.financial_impact, sourceCurrency)}
-      </div>
+        <div className="flex items-center gap-2 font-mono text-sm">
+          {currency.format(scenario.financial_impact, sourceCurrency)}
+          {isOpen ? (
+            <ChevronUp className="size-4 text-navy/40" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="size-4 text-navy/40" aria-hidden="true" />
+          )}
+        </div>
+      </button>
+      {isOpen ? (
+        <div className="flex flex-col gap-2 px-3 pb-3 text-xs">
+          {parsedDetails ? (
+            <dl className="grid grid-cols-2 gap-3 md:grid-cols-4">
+              {Object.entries(parsedDetails).map(([k, v]) => (
+                <div key={k} className="flex flex-col">
+                  <span className="kpi-label">{k}</span>
+                  <span className="font-mono text-navy">{String(v)}</span>
+                </div>
+              ))}
+            </dl>
+          ) : scenario.details ? (
+            <pre className="overflow-x-auto rounded bg-ice-50 p-2 font-mono text-[11px]">
+              {scenario.details}
+            </pre>
+          ) : null}
+          {scenario.outcome_notes ? (
+            <p className="italic text-navy/80">
+              Proposed action: {scenario.outcome_notes}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
     </li>
   );
 }
 
 function ResourceRowView({
   row,
+  isOpen,
+  onToggle,
   currencyFormat,
 }: {
   row: ResourceRow;
+  isOpen: boolean;
+  onToggle: () => void;
   currencyFormat: (amount: number | null, src: string) => string;
 }) {
   return (
-    <tr className="border-t border-ice-100">
-      <td className="py-2 font-medium">{row.name}</td>
-      <td>{row.role ?? "—"}</td>
-      <td>{row.role_tier ?? "—"}</td>
-      <td className="text-right font-mono">
-        {row.utilization_pct === null ? "—" : formatPct(row.utilization_pct / 100)}
-      </td>
-      <td className="text-right font-mono">
-        <Badge tone={row.bench_days > 0 ? "red" : "green"}>
-          {row.bench_days === 0 ? (
-            <CheckCircle2 className="size-3" aria-hidden="true" />
-          ) : null}
-          {row.bench_days}d
-        </Badge>
-      </td>
-      <td className="text-right font-mono">
-        {currencyFormat(row.loaded_cost_annual, "INR")}
-      </td>
-      <td>
-        <Badge tone={row.status === "Bench" ? "red" : "green"}>{row.status}</Badge>
-      </td>
-    </tr>
+    <Fragment>
+      <tr
+        role="button"
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        className="cursor-pointer border-t border-ice-100 transition hover:bg-ice-50"
+        aria-expanded={isOpen}
+      >
+        <td className="py-2 font-medium">{row.name}</td>
+        <td>{row.role ?? "—"}</td>
+        <td>{row.role_tier ?? "—"}</td>
+        <td className="text-right font-mono">
+          {row.utilization_pct === null ? "—" : formatPct(row.utilization_pct / 100)}
+        </td>
+        <td className="text-right font-mono">
+          <Badge tone={row.bench_days > 0 ? "red" : "green"}>
+            {row.bench_days === 0 ? (
+              <CheckCircle2 className="size-3" aria-hidden="true" />
+            ) : null}
+            {row.bench_days}d
+          </Badge>
+        </td>
+        <td className="text-right font-mono">
+          {currencyFormat(row.loaded_cost_annual, "INR")}
+        </td>
+        <td>
+          <Badge tone={row.status === "Bench" ? "red" : "green"}>{row.status}</Badge>
+        </td>
+        <td className="pr-2 text-right text-navy/40">
+          {isOpen ? (
+            <ChevronUp className="inline size-4" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="inline size-4" aria-hidden="true" />
+          )}
+        </td>
+      </tr>
+      {isOpen ? (
+        <tr className="bg-ice-50/40">
+          <td colSpan={8} className="px-3 py-3 text-xs text-navy/80">
+            <dl className="grid grid-cols-2 gap-3 md:grid-cols-4">
+              <Detail label="Skills" value={row.skill_set ?? "—"} />
+              <Detail
+                label="Current programme"
+                value={row.current_program_id ? `#${row.current_program_id}` : "—"}
+              />
+              <Detail
+                label="Current project"
+                value={row.current_project_id ? `#${row.current_project_id}` : "—"}
+              />
+              <Detail
+                label="Bench daily drag"
+                value={
+                  row.loaded_cost_annual
+                    ? currencyFormat(row.loaded_cost_annual / 365, "INR")
+                    : "—"
+                }
+              />
+            </dl>
+          </td>
+        </tr>
+      ) : null}
+    </Fragment>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="kpi-label">{label}</span>
+      <span className="font-mono text-navy">{value}</span>
+    </div>
   );
 }
 

--- a/frontend/src/pages/VelocityFlow.tsx
+++ b/frontend/src/pages/VelocityFlow.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Bar,
@@ -14,8 +14,10 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { CheckCircle2, Home, XCircle, ChevronRight, X } from "lucide-react";
+import { CheckCircle2, Home, XCircle } from "lucide-react";
 import { Breadcrumb } from "@/components/Breadcrumb";
+import { ProgrammeFilterBar } from "@/components/ProgrammeFilterBar";
+import { PROGRAMME_CROSS_LINKS } from "@/components/programmeCrossLinks";
 import { Card, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import {
@@ -27,7 +29,7 @@ import { useProgrammes } from "@/hooks/usePortfolio";
 import { formatPct, formatRatio } from "@/lib/format";
 
 export function VelocityFlow() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const programmeFilter = searchParams.get("programme");
   const programmes = useProgrammes();
 
@@ -44,12 +46,6 @@ export function VelocityFlow() {
     queryKey: ["blend-rules", filteredProgramme?.id ?? null],
     queryFn: () => fetchBlendRules(filteredProgramme?.id),
   });
-
-  const clearProgrammeFilter = () => {
-    const next = new URLSearchParams(searchParams);
-    next.delete("programme");
-    setSearchParams(next);
-  };
 
   const projectSeries = useMemo(() => {
     const rows = dual.data ?? [];
@@ -116,38 +112,19 @@ export function VelocityFlow() {
     <div className="flex flex-col gap-6">
       <Breadcrumb items={breadcrumbItems} />
 
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold text-navy">Velocity & Flow</h1>
-          <p className="mt-1 text-sm text-navy/70">
-            Is AI-augmented velocity real or illusory? This tab pairs raw AI
-            output with a quality-adjusted view and the blend-rule gates that
-            decide whether AI velocity can count towards the plan.
-          </p>
-        </div>
-        {filteredProgramme ? (
-          <Link
-            to={`/delivery?programme=${filteredProgramme.code}`}
-            className="btn-ghost"
-          >
-            View Delivery Health <ChevronRight className="size-3" />
-          </Link>
-        ) : null}
+      <div>
+        <h1 className="text-2xl font-semibold text-navy">Velocity & Flow</h1>
+        <p className="mt-1 text-sm text-navy/70">
+          Is AI-augmented velocity real or illusory? This tab pairs raw AI
+          output with a quality-adjusted view and the blend-rule gates that
+          decide whether AI velocity can count towards the plan.
+        </p>
       </div>
 
-      {filteredProgramme ? (
-        <div className="inline-flex items-center gap-2 self-start rounded-full border border-navy/30 bg-navy/5 px-3 py-1 text-xs text-navy">
-          Filtered to <strong>{filteredProgramme.name}</strong>
-          <button
-            type="button"
-            onClick={clearProgrammeFilter}
-            className="inline-flex items-center rounded-full bg-navy/10 px-1.5 py-0.5 transition hover:bg-navy/20"
-            aria-label="Clear programme filter (drill up)"
-          >
-            <X className="size-3" /> clear
-          </button>
-        </div>
-      ) : null}
+      <ProgrammeFilterBar
+        currentRoute="/velocity"
+        crossLinks={PROGRAMME_CROSS_LINKS}
+      />
 
       {aggregate ? (
         <section className="grid grid-cols-2 gap-3 md:grid-cols-4">

--- a/scripts/com.akb1.dashboard.plist
+++ b/scripts/com.akb1.dashboard.plist
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AKB1 Command Center — macOS LaunchAgent
+  Installs as a per-user agent that runs `docker compose up -d` on every login.
+
+  Install:
+    cp scripts/com.akb1.dashboard.plist ~/Library/LaunchAgents/
+    launchctl load -w ~/Library/LaunchAgents/com.akb1.dashboard.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.akb1.dashboard.plist
+    rm ~/Library/LaunchAgents/com.akb1.dashboard.plist
+
+  Logs:
+    /tmp/akb1-launch.log  (stdout + stderr)
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.akb1.dashboard</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>-c</string>
+      <!--
+        Wait up to 90s for Docker Desktop to come up before running compose.
+        Uses only binaries that exist on a fresh macOS + Homebrew path so the
+        agent works even when the user shell profile hasn't been sourced.
+      -->
+      <string>
+        export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+        cd "$HOME/Documents/Claude/Claude_Code/Projects/akb1-command-center" || exit 1;
+        for i in $(seq 1 30); do
+          if docker info &gt; /dev/null 2&gt;&amp;1; then
+            break;
+          fi;
+          sleep 3;
+        done;
+        docker compose up -d
+      </string>
+    </array>
+
+    <!-- Run once at login. -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- If it fails, retry every 5 minutes for up to 3 attempts. -->
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/akb1-launch.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/akb1-launch.log</string>
+
+    <!-- Inherit the user's HOME correctly. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>LANG</key>
+      <string>en_US.UTF-8</string>
+    </dict>
+  </dict>
+</plist>

--- a/scripts/install-autostart.sh
+++ b/scripts/install-autostart.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Install the AKB1 Command Center LaunchAgent so the stack boots on login.
+# macOS only. Idempotent.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLIST_SRC="$REPO_DIR/scripts/com.akb1.dashboard.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.akb1.dashboard.plist"
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "This installer is macOS-only. See docs/RUN_BOOK.md §3 for Linux/systemd guidance (planned)."
+  exit 1
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents"
+
+# If a previous copy exists, unload it first so launchctl picks up the new version.
+if launchctl list | grep -q com.akb1.dashboard; then
+  launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+cp "$PLIST_SRC" "$PLIST_DEST"
+launchctl load -w "$PLIST_DEST"
+
+echo "AKB1 dashboard LaunchAgent installed."
+echo "Logs → /tmp/akb1-launch.log"
+echo "Disable → launchctl unload $PLIST_DEST"


### PR DESCRIPTION
## Summary
Two deliveries bundled:

1. **Drill nav v3** — shared `ProgrammeFilterBar` component retrofitted across every programme-scoped tab so drill-up / drill-across / drill-through behave identically everywhere. Tabs 4-7 gain prev/next + cross-tab drills; Tabs 8-9 gain `?programme=` filtering + cross-tab drills. Row-level leaf drill-down added for CRs, actions, SLA incidents, scenarios, resources, and risks.
2. **Operational runbook** (`docs/RUN_BOOK.md`) + macOS LaunchAgent (`scripts/com.akb1.dashboard.plist`) so the stack auto-starts on login.

## Drill matrix after this PR

| Tab | Breadcrumb | `?programme=` | Clear | Prev/Next | Cross-tab links | Row expand |
|---|---|---|---|---|---|---|
| 1 Executive | ✅ | N/A (portfolio view) | ✅ (RAG) | N/A | ✅ | ✅ |
| 2 KPI Studio | ✅ | ✅ | ✅ | ✅ | ✅ | partial |
| 3 Delivery | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| **4 Velocity** | ✅ | ✅ | ✅ | **✅ new** | **✅ new** | — |
| **5 Margin & EVM** | ✅ | ✅ | ✅ | **✅ new** | **✅ new** | **✅ new (CRs)** |
| **6 Customer** | ✅ | ✅ | ✅ | **✅ new** | **✅ new** | **✅ new (actions, SLA)** |
| **7 AI Governance** | ✅ | ✅ | ✅ | **✅ new** | **✅ new** | — |
| **8 Smart Ops** | ✅ | **✅ new** | **✅ new** | **✅ new** | **✅ new** | **✅ new (scenarios, resources)** |
| **9 Risk & Audit** | ✅ | **✅ new** | **✅ new** | **✅ new** | **✅ new** | **✅ new (risks)** |

## Runbook + auto-start
- `docs/RUN_BOOK.md` — daily workflow, deep-link URLs, config reference, troubleshooting matrix, developer-mode, security reminders.
- `scripts/com.akb1.dashboard.plist` — waits up to 90s for Docker daemon on login, then runs `docker compose up -d`.
- `scripts/install-autostart.sh` — one-liner installer.

## Quality gates
- TypeScript strict build green · ESLint clean · Vitest 17/17 pass
- Manual exercise: `/smart-ops?programme=PHOENIX` responds 200, filter carries across every peer tab via cross-link chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)