### PR TITLE
feat: Iteration 4a — Tab 10 Reports + forecasts + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,92 @@
+# Changelog
+
+All notable changes to **AKB1 Command Center** are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning is calendar-style because this is a solo-maintained portfolio build, not a library.
+
+## [Unreleased] — Iteration 4 (in flight)
+
+### Added
+- **Tab 10 Reports & Exports** (`/reports`): per-programme QBR PDF (ReportLab), portfolio-wide and per-programme audit evidence ZIP (JSON dumps + README), configurable 3-month forecast chart with three parallel models.
+- `GET /api/v1/reports/qbr/{program_id}.pdf` and `/api/v1/reports/audit-package.zip` endpoints.
+- `GET /api/v1/forecasts` — wraps `app/services/forecast.py` primitives (linear trend, weighted moving average, exponential smoothing) into an HTTP surface.
+- ReportLab runtime dependency.
+
+### Planned for the same iteration (see ROADMAP)
+- Playwright E2E golden-path test
+- axe-core accessibility pass across every tab
+- CycloneDX SBOM for backend + frontend
+- Cold-start timing script — clone → `docker compose up` → dashboard in under 3 minutes
+
+---
+
+## 2026-04-20 — Iteration 3d (PR #8)
+
+### Added
+- Shared `ProgrammeFilterBar` + `programmeCrossLinks` module. Retrofitted across Tabs 4–9 to standardise drill-up / drill-across / drill-through navigation.
+- `?programme=CODE` filtering on Tab 8 (Smart Ops) and Tab 9 (Risk & Audit).
+- Row-level leaf drill-down (inline expand) for change requests (Tab 5), customer actions + SLA incidents (Tab 6), scenarios + resources (Tab 8), risk register (Tab 9).
+- `docs/RUN_BOOK.md` — daily workflow, URL deep-links, troubleshooting matrix, developer-mode, security reminders.
+- `scripts/com.akb1.dashboard.plist` + `scripts/install-autostart.sh` — macOS LaunchAgent that brings the stack up on login.
+
+## 2026-04-20 — Iteration 3c (PR #7)
+
+### Added
+- **Tab 8 Smart Ops** (`/smart-ops`): 8 proactive-detection scenarios, status filter, resource pool table.
+- **Tab 9 Risk & Audit** (`/raid`): risk register, compliance scorecard, filtered audit trail with old→new diff, 7-dimension audit-readiness matrix.
+- Seed: 8 `scenario_executions`, 10 `resource_pool` rows (2 bench), 8 representative `audit_log` entries.
+- Endpoints: `/api/v1/smart-ops/scenarios`, `/smart-ops/resources`, `/audit`.
+
+## 2026-04-20 — Iteration 3b (PR #6)
+
+### Added
+- **Tab 7 AI Governance** (`/ai`): 6-factor trust composite radar, productivity-tax comparison, governance controls table, override log, tool catalogue.
+- 8 new AI endpoints (`/api/v1/ai/*`).
+- Seed `app/seed/ai_data.py`: 5 tools, 9 assignments, ~35 usage rows, 12 code-metric sprint rows, 12 SDLC rows, 4 trust scores, 6 governance items, 5 overrides.
+
+## 2026-04-20 — Iteration 3a (PR #5)
+
+### Added
+- **Tab 6 Customer Intelligence** (`/customer`): CSAT / NPS / Renewal trend, 7-dimension Expectation Gap radar, communication tracker, action items, SLA ledger.
+- Endpoints: `/api/v1/customer/satisfaction`, `/customer/sla-incidents`.
+- Seed: 60 `customer_satisfaction` rows (5 programmes × 12 months), 8 `sla_incidents` including 4 breaches.
+
+## 2026-04-20 — Iteration 2c (PR #4)
+
+### Added
+- **Tab 4 Velocity & Flow** (`/velocity`) with dual-velocity chart and blend-rule gates.
+- **Tab 5 Margin & EVM** (`/margin`) with 4-layer margin waterfall, 7-loss horizontal bars, rate-card drift table, change-request ledger.
+- 6 endpoints: `/dual-velocity`, `/blend-rules`, `/commercial`, `/losses`, `/rate-cards`, `/change-requests`.
+- Seed: 12 dual-velocity rows, 7 blend rules, 20 commercial scenarios, 13 losses, 15 rate-card rows, 6 change requests.
+
+## 2026-04-20 — Iteration 2b (PR #3)
+
+### Added
+- **Tab 3 Delivery Health** (`/delivery`) as a methodology-adaptive view: Scrum (sprint burndown, velocity + rework, optional dual-velocity), Kanban (ECharts cumulative flow diagram, cycle-time percentiles), Waterfall (phase timeline with gates, milestone list).
+- Common EVM strip (CPI / SPI / EAC / TCPI / % complete) + 12-month EVM trend.
+- 5 new endpoints: `/sprints`, `/evm`, `/flow`, `/phases`, `/milestones`.
+- Delivery seed: 18 Scrum sprints, 24 weeks of Kanban flow rows, 6 Waterfall phases, 72 EVM snapshots, 26 milestones.
+- Drill navigation v1: breadcrumb component, programme rows clickable on Tab 1, clear-filter chips, prev/next project drill-across, cross-tab links between Delivery and KPI Studio, expandable sprint / phase / milestone rows.
+
+## 2026-04-20 — Iteration 2a (PR #2)
+
+### Added
+- **Tab 2 KPI Studio** (`/kpi`): grouped KPI library, threshold-band trend chart, inline weight editor (optimistic + 422 rollback), latest-value RAG table, formula modal.
+- Seed expanded 6 → 13 KPI definitions (Delivery, Quality, People, Commercial, AI).
+- API: `?category=` filter, `PUT /kpi/definitions/{id}/weight`, single-definition GET, `kpi_id` snapshot filter.
+- Multi-currency: `GET /api/v1/currency/rates`, `CurrencySelector` in top bar, conversion math anchored to USD (default currency switched from INR to USD). Seeded rates INR 83.50, GBP 0.79, EUR 0.93.
+- CORS / same-origin: nginx now proxies `/api` + `/health`, so the browser always talks to a single origin.
+
+## 2026-04-20 — Iteration 1 (PR #1)
+
+### Added
+- FastAPI backend with 44 SQLAlchemy 2.0 async models (matching ARCHITECTURE.md §5).
+- SQLite WAL engine, structlog JSON logging, slowapi rate limiting, Alembic initial migration.
+- NovaTech demo seeder: 5 programmes × 12 months, 6 projects, 6 KPI definitions, 5 risks, 7 customer expectations, 6 customer actions, app_settings defaults, currency rates.
+- REST v1: `/health`, `/programmes` (+ nested projects), `/kpi/{definitions,snapshots}`, `/risks`, `/customer/{id}/expectations`, `/customer/{id}/actions`, `/settings`, `/import/csv/preview`.
+- Vite 5 + React 18 + TypeScript + Tailwind with AKB1 brand tokens.
+- Tab 1 Executive Overview, Tab 11 Data Hub & Settings.
+- Docker compose hardening: localhost-bound ports, non-root UID 1001, `read_only: true`, `cap_drop: ALL`, tmpfs mounts.
+- CI workflow (`.github/workflows/ci.yml`): backend-test (ruff + pytest coverage gate), frontend-lint (ESLint + Vitest + build), docker-build (compose smoke).
+
+### Fixed during post-merge
+- Async SQLite URL used 3-slash relative path, which collided with `read_only: true` inside the container — compose default now uses 4-slash absolute path to the mounted `/data` volume.
+- `CORS_ORIGINS` JSON decode conflict on pydantic-settings: switched to comma-separated string + computed list property.

--- a/backend/app/api/v1/forecasts.py
+++ b/backend/app/api/v1/forecasts.py
@@ -1,0 +1,125 @@
+"""KPI forecast endpoint — thin wrapper around app/services/forecast.py.
+
+Pulls the historical snapshots for a KPI + programme, runs the three
+forecast primitives (linear trend, weighted moving average, exponential
+smoothing), and returns the next 3 months projected. No persistence —
+frontends can re-request whenever they like.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.models import KpiDefinition, KpiSnapshot, Program
+from app.services.forecast import (
+    exponential_smoothing,
+    linear_trend,
+    weighted_moving_average,
+)
+
+router = APIRouter(prefix="/forecasts", tags=["forecasts"])
+
+
+class ForecastSeries(BaseModel):
+    label: str
+    values: list[float]
+
+
+class ForecastOut(BaseModel):
+    kpi_code: str
+    programme_code: str | None
+    historical_dates: list[date]
+    historical_values: list[float]
+    horizon_months: int
+    horizon_labels: list[str]
+    series: list[ForecastSeries]
+
+
+def _next_month_labels(last_date: date, horizon: int) -> list[str]:
+    labels: list[str] = []
+    year, month = last_date.year, last_date.month
+    for _ in range(horizon):
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+        labels.append(f"{year:04d}-{month:02d}")
+    return labels
+
+
+@router.get("", response_model=ForecastOut)
+async def build_forecast(
+    kpi_code: str = Query(..., description="KPI code, e.g. CPI / MARGIN"),
+    programme_code: str | None = Query(default=None),
+    horizon: int = Query(default=3, ge=1, le=12),
+    session: AsyncSession = Depends(get_session),
+) -> ForecastOut:
+    kpi = (
+        await session.execute(
+            select(KpiDefinition).where(KpiDefinition.code == kpi_code)
+        )
+    ).scalar_one_or_none()
+    if kpi is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="KPI code not found"
+        )
+
+    program_id: int | None = None
+    if programme_code is not None:
+        programme = (
+            await session.execute(
+                select(Program).where(Program.code == programme_code)
+            )
+        ).scalar_one_or_none()
+        if programme is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Programme code not found"
+            )
+        program_id = programme.id
+
+    stmt = (
+        select(KpiSnapshot)
+        .where(KpiSnapshot.kpi_id == kpi.id)
+        .order_by(KpiSnapshot.snapshot_date.asc())
+    )
+    if program_id is not None:
+        stmt = stmt.where(KpiSnapshot.program_id == program_id)
+    snapshots = (await session.execute(stmt)).scalars().all()
+
+    if len(snapshots) == 0:
+        return ForecastOut(
+            kpi_code=kpi_code,
+            programme_code=programme_code,
+            historical_dates=[],
+            historical_values=[],
+            horizon_months=horizon,
+            horizon_labels=[],
+            series=[],
+        )
+
+    values = [s.value for s in snapshots]
+    dates = [s.snapshot_date for s in snapshots]
+    last_date = dates[-1]
+
+    linear = linear_trend(values, horizon=horizon)
+    wma = [weighted_moving_average(values, window=3)] * horizon
+    exp = [exponential_smoothing(values, alpha=0.4)] * horizon
+
+    return ForecastOut(
+        kpi_code=kpi_code,
+        programme_code=programme_code,
+        historical_dates=dates,
+        historical_values=values,
+        horizon_months=horizon,
+        horizon_labels=_next_month_labels(last_date, horizon),
+        series=[
+            ForecastSeries(label="Linear trend", values=linear),
+            ForecastSeries(label="Weighted moving avg", values=wma),
+            ForecastSeries(label="Exponential smoothing", values=exp),
+        ],
+    )

--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -1,0 +1,238 @@
+"""Tab 10 Reports & Exports endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.models import (
+    AuditLog,
+    CommercialScenario,
+    CustomerAction,
+    CustomerSatisfaction,
+    EvmSnapshot,
+    KpiSnapshot,
+    Program,
+    Risk,
+    ScopeCreepLog,
+    SlaIncident,
+)
+from app.services.reports import build_audit_zip, build_qbr_pdf
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+
+async def _require_programme(session: AsyncSession, program_id: int) -> Program:
+    programme = await session.get(Program, program_id)
+    if programme is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Programme not found"
+        )
+    return programme
+
+
+def _format_currency(amount: float | None, symbol: str = "₹") -> str:
+    if amount is None:
+        return "—"
+    abs_amount = abs(amount)
+    if abs_amount >= 1e7:
+        return f"{symbol}{amount / 1e7:.2f} Cr"
+    if abs_amount >= 1e5:
+        return f"{symbol}{amount / 1e5:.2f} L"
+    return f"{symbol}{amount:,.0f}"
+
+
+@router.get("/qbr/{program_id}.pdf", response_class=Response)
+async def qbr_pdf(
+    program_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    programme = await _require_programme(session, program_id)
+
+    latest_cs = (
+        await session.execute(
+            select(CustomerSatisfaction)
+            .where(CustomerSatisfaction.program_id == program_id)
+            .order_by(CustomerSatisfaction.snapshot_date.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    latest_evm = (
+        await session.execute(
+            select(EvmSnapshot)
+            .where(EvmSnapshot.program_id == program_id)
+            .order_by(EvmSnapshot.snapshot_date.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    latest_commercial = (
+        await session.execute(
+            select(CommercialScenario)
+            .where(CommercialScenario.program_id == program_id)
+            .order_by(CommercialScenario.snapshot_date.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    top_risks = (
+        await session.execute(
+            select(Risk)
+            .where(Risk.program_id == program_id)
+            .order_by(Risk.impact.desc().nulls_last())
+            .limit(5)
+        )
+    ).scalars().all()
+
+    open_actions = (
+        await session.execute(
+            select(CustomerAction)
+            .where(
+                CustomerAction.program_id == program_id,
+                CustomerAction.status != "Closed",
+            )
+            .order_by(CustomerAction.due_date.asc().nulls_last())
+            .limit(6)
+        )
+    ).scalars().all()
+
+    commentary_parts = [
+        f"{programme.name} is currently {programme.status}. ",
+    ]
+    if latest_cs:
+        commentary_parts.append(
+            f"CSAT {latest_cs.csat_score:.1f} / NPS {latest_cs.nps_score:.0f} / "
+            f"Renewal probability {latest_cs.renewal_score:.0f}%. "
+        )
+    if latest_evm and latest_evm.cpi is not None:
+        commentary_parts.append(
+            f"Earned-value metrics: CPI {latest_evm.cpi:.2f}, "
+            f"SPI {(latest_evm.spi or 0):.2f}. "
+        )
+    if latest_commercial and latest_commercial.net_margin_pct is not None:
+        commentary_parts.append(
+            f"Net margin {latest_commercial.net_margin_pct * 100:.1f}%."
+        )
+
+    symbol = "₹" if programme.currency_code == "INR" else "$"
+    context = {
+        "programme": {
+            "name": programme.name,
+            "code": programme.code,
+            "client": programme.client or "—",
+            "currency_code": programme.currency_code,
+        },
+        "snapshot": {
+            "status": programme.status,
+            "revenue": _format_currency(programme.revenue, symbol),
+            "cpi": f"{latest_evm.cpi:.2f}" if latest_evm and latest_evm.cpi else "—",
+            "spi": f"{latest_evm.spi:.2f}" if latest_evm and latest_evm.spi else "—",
+            "margin": (
+                f"{latest_commercial.net_margin_pct * 100:.1f}%"
+                if latest_commercial and latest_commercial.net_margin_pct is not None
+                else "—"
+            ),
+            "renewal_score": (
+                f"{latest_cs.renewal_score:.0f}%"
+                if latest_cs and latest_cs.renewal_score is not None
+                else "—"
+            ),
+        },
+        "commentary": "".join(commentary_parts),
+        "top_risks": [
+            {
+                "title": r.title,
+                "severity": r.severity or "—",
+                "impact_display": _format_currency(r.impact, symbol),
+                "owner": r.owner or "—",
+            }
+            for r in top_risks
+        ],
+        "open_actions": [
+            {
+                "description": a.description,
+                "owner": a.owner or "—",
+                "due_date": str(a.due_date) if a.due_date else "—",
+                "priority": a.priority or "—",
+            }
+            for a in open_actions
+        ],
+    }
+
+    pdf = build_qbr_pdf(context)
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="qbr-{programme.code.lower()}.pdf"'
+            )
+        },
+    )
+
+
+@router.get("/audit-package.zip", response_class=Response)
+async def audit_package_zip(
+    program_id: int | None = None,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Bundle the audit-evidence JSON dumps for the requested scope.
+
+    Payload includes: audit_log, risks, scope_creep_log, sla_incidents,
+    kpi_snapshots, customer_satisfaction. Filtered to a programme when
+    program_id is provided.
+    """
+    queries = {
+        "audit_log": select(AuditLog).order_by(AuditLog.timestamp.desc()).limit(200),
+    }
+    scoped = {
+        "risks": select(Risk),
+        "scope_creep_log": select(ScopeCreepLog),
+        "sla_incidents": select(SlaIncident),
+        "kpi_snapshots": select(KpiSnapshot).limit(500),
+        "customer_satisfaction": select(CustomerSatisfaction),
+    }
+    if program_id is not None:
+        await _require_programme(session, program_id)
+        scoped["risks"] = scoped["risks"].where(Risk.program_id == program_id)
+        scoped["scope_creep_log"] = scoped["scope_creep_log"].where(
+            ScopeCreepLog.program_id == program_id
+        )
+        scoped["sla_incidents"] = scoped["sla_incidents"].where(
+            SlaIncident.program_id == program_id
+        )
+        scoped["kpi_snapshots"] = scoped["kpi_snapshots"].where(
+            KpiSnapshot.program_id == program_id
+        )
+        scoped["customer_satisfaction"] = scoped["customer_satisfaction"].where(
+            CustomerSatisfaction.program_id == program_id
+        )
+
+    bundle: dict[str, list[dict[str, object]]] = {}
+    for name, stmt in {**queries, **scoped}.items():
+        rows = (await session.execute(stmt)).scalars().all()
+        bundle[name] = [_row_to_dict(r) for r in rows]
+
+    zip_bytes = build_audit_zip(bundle)
+    filename = (
+        f"audit-{program_id}.zip" if program_id is not None else "audit-portfolio.zip"
+    )
+    return Response(
+        content=zip_bytes,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+def _row_to_dict(row: object) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for col in row.__table__.columns:  # type: ignore[attr-defined]
+        value = getattr(row, col.name)
+        if hasattr(value, "isoformat"):
+            result[col.name] = value.isoformat()
+        else:
+            result[col.name] = value
+    return result

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -9,10 +9,12 @@ from app.api.v1 import (
     customer,
     data_import,
     delivery,
+    forecasts,
     health,
     kpi,
     ops,
     programmes,
+    reports,
     risks,
     settings,
 )
@@ -46,5 +48,7 @@ api_router.include_router(ai.override_router)
 api_router.include_router(ops.scenarios_router)
 api_router.include_router(ops.resources_router)
 api_router.include_router(ops.audit_router)
+api_router.include_router(reports.router)
+api_router.include_router(forecasts.router)
 api_router.include_router(settings.router)
 api_router.include_router(data_import.router)

--- a/backend/app/services/reports.py
+++ b/backend/app/services/reports.py
@@ -1,0 +1,252 @@
+"""Report generation — QBR brief + audit package.
+
+Keeps PDF assembly behind a thin service layer so the API handler stays
+small and the same functions can be reused from scheduled jobs later.
+"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime
+from typing import Any
+
+from reportlab.lib.colors import HexColor
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.platypus import (
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+NAVY = HexColor("#1B2A4A")
+AMBER = HexColor("#F59E0B")
+ICE = HexColor("#D5E8F0")
+
+
+def _styles() -> dict[str, ParagraphStyle]:
+    base = getSampleStyleSheet()
+    title = ParagraphStyle(
+        "AkbTitle",
+        parent=base["Title"],
+        textColor=NAVY,
+        fontName="Helvetica-Bold",
+        fontSize=22,
+        leading=26,
+        spaceAfter=4,
+    )
+    subtitle = ParagraphStyle(
+        "AkbSubtitle",
+        parent=base["Heading3"],
+        textColor=NAVY,
+        fontName="Helvetica",
+        fontSize=11,
+        leading=14,
+        spaceAfter=12,
+    )
+    h2 = ParagraphStyle(
+        "AkbH2",
+        parent=base["Heading2"],
+        textColor=NAVY,
+        fontName="Helvetica-Bold",
+        fontSize=13,
+        leading=16,
+        spaceBefore=14,
+        spaceAfter=6,
+    )
+    body = ParagraphStyle(
+        "AkbBody",
+        parent=base["BodyText"],
+        textColor=NAVY,
+        fontName="Helvetica",
+        fontSize=10,
+        leading=13,
+        spaceAfter=8,
+    )
+    return {"title": title, "subtitle": subtitle, "h2": h2, "body": body}
+
+
+def _kv_table(pairs: list[tuple[str, str]], col1: float = 55, col2: float = 115) -> Table:
+    data = [[k, v] for k, v in pairs]
+    tbl = Table(data, colWidths=[col1 * mm, col2 * mm])
+    tbl.setStyle(
+        TableStyle(
+            [
+                ("FONT", (0, 0), (-1, -1), "Helvetica", 10),
+                ("TEXTCOLOR", (0, 0), (-1, -1), NAVY),
+                ("BACKGROUND", (0, 0), (0, -1), ICE),
+                ("BOX", (0, 0), (-1, -1), 0.4, NAVY),
+                ("INNERGRID", (0, 0), (-1, -1), 0.25, NAVY),
+                ("ALIGN", (0, 0), (0, -1), "LEFT"),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        ),
+    )
+    return tbl
+
+
+def build_qbr_pdf(context: dict[str, Any]) -> bytes:
+    """Render a single-page QBR PDF for a programme context."""
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=A4,
+        leftMargin=18 * mm,
+        rightMargin=18 * mm,
+        topMargin=18 * mm,
+        bottomMargin=18 * mm,
+        title=f"QBR Brief — {context.get('programme', {}).get('name', '—')}",
+        author="AKB1 Command Center",
+    )
+    styles = _styles()
+    story: list[Any] = []
+    programme = context.get("programme", {})
+
+    story.append(Paragraph(f"QBR Brief · {programme.get('name', '—')}", styles["title"]))
+    story.append(
+        Paragraph(
+            f"Programme code <b>{programme.get('code', '—')}</b> &nbsp;·&nbsp; "
+            f"Client <b>{programme.get('client', '—')}</b> &nbsp;·&nbsp; "
+            f"Generated {datetime.utcnow().strftime('%Y-%m-%d %H:%MZ')}",
+            styles["subtitle"],
+        ),
+    )
+
+    story.append(Paragraph("Snapshot", styles["h2"]))
+    snapshot = context.get("snapshot", {})
+    story.append(
+        _kv_table(
+            [
+                ("Status", snapshot.get("status", "—")),
+                ("Revenue (native)", snapshot.get("revenue", "—")),
+                ("Latest CPI", snapshot.get("cpi", "—")),
+                ("Latest SPI", snapshot.get("spi", "—")),
+                ("Latest margin", snapshot.get("margin", "—")),
+                ("Renewal probability", snapshot.get("renewal_score", "—")),
+            ]
+        ),
+    )
+
+    story.append(Paragraph("Commentary", styles["h2"]))
+    commentary = context.get("commentary", "No commentary available.")
+    story.append(Paragraph(commentary.replace("\n", "<br/>"), styles["body"]))
+
+    top_risks = context.get("top_risks") or []
+    if top_risks:
+        story.append(Paragraph("Top risks by financial impact", styles["h2"]))
+        data = [["Title", "Severity", "Impact", "Owner"]]
+        for r in top_risks[:5]:
+            data.append(
+                [
+                    r.get("title", "—"),
+                    r.get("severity", "—"),
+                    r.get("impact_display", "—"),
+                    r.get("owner", "—"),
+                ]
+            )
+        tbl = Table(data, colWidths=[70 * mm, 24 * mm, 32 * mm, 34 * mm])
+        tbl.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), NAVY),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), HexColor("#FFFFFF")),
+                    ("FONT", (0, 0), (-1, 0), "Helvetica-Bold", 10),
+                    ("FONT", (0, 1), (-1, -1), "Helvetica", 9),
+                    ("TEXTCOLOR", (0, 1), (-1, -1), NAVY),
+                    ("BOX", (0, 0), (-1, -1), 0.4, NAVY),
+                    ("INNERGRID", (0, 0), (-1, -1), 0.2, NAVY),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 5),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 5),
+                    ("TOPPADDING", (0, 0), (-1, -1), 3),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ]
+            ),
+        )
+        story.append(tbl)
+
+    open_actions = context.get("open_actions") or []
+    if open_actions:
+        story.append(Spacer(1, 6))
+        story.append(Paragraph("Open steering-committee actions", styles["h2"]))
+        data = [["Description", "Owner", "Due", "Priority"]]
+        for a in open_actions[:6]:
+            data.append(
+                [
+                    a.get("description", "—"),
+                    a.get("owner", "—"),
+                    a.get("due_date", "—"),
+                    a.get("priority", "—"),
+                ]
+            )
+        tbl = Table(data, colWidths=[88 * mm, 30 * mm, 22 * mm, 20 * mm])
+        tbl.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), AMBER),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), NAVY),
+                    ("FONT", (0, 0), (-1, 0), "Helvetica-Bold", 10),
+                    ("FONT", (0, 1), (-1, -1), "Helvetica", 9),
+                    ("TEXTCOLOR", (0, 1), (-1, -1), NAVY),
+                    ("BOX", (0, 0), (-1, -1), 0.4, NAVY),
+                    ("INNERGRID", (0, 0), (-1, -1), 0.2, NAVY),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 5),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 5),
+                    ("TOPPADDING", (0, 0), (-1, -1), 3),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ]
+            ),
+        )
+        story.append(tbl)
+
+    story.append(Spacer(1, 12))
+    story.append(
+        Paragraph(
+            "Generated by AKB1 Command Center v5.2 · Source: "
+            "github.com/deva-adi/akb1-command-center",
+            ParagraphStyle(
+                "Footer",
+                parent=styles["body"],
+                fontSize=8,
+                textColor=HexColor("#7B8AA1"),
+                alignment=1,
+            ),
+        ),
+    )
+
+    doc.build(story)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def build_audit_zip(bundle: dict[str, Any]) -> bytes:
+    """Package an audit evidence ZIP from a JSON-serialisable bundle."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, payload in bundle.items():
+            data = (
+                payload
+                if isinstance(payload, (bytes, bytearray))
+                else json.dumps(payload, default=str, indent=2).encode("utf-8")
+            )
+            suffix = ".bin" if isinstance(payload, (bytes, bytearray)) else ".json"
+            zf.writestr(f"{name}{suffix}", data)
+        zf.writestr(
+            "README.txt",
+            "AKB1 Command Center — Audit evidence package\n"
+            f"Generated: {datetime.utcnow().isoformat()}Z\n"
+            "Contents: each .json is a direct dump of the referenced table, "
+            "filtered to the requested scope. See docs/SECURITY_GUIDE.md for the "
+            "audit-readiness mapping.\n",
+        )
+    buf.seek(0)
+    return buf.getvalue()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,9 @@ pydantic>=2.5.0
 pydantic-settings>=2.1.0
 python-multipart>=0.0.9
 
+# Reports & exports (Tab 10)
+reportlab>=4.0.0
+
 # Database & migrations
 aiosqlite>=0.19.0
 sqlalchemy[asyncio]>=2.0.25

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { DeliveryHealth } from "@/pages/DeliveryHealth";
 import { KpiStudio } from "@/pages/KpiStudio";
 import { MarginEvm } from "@/pages/MarginEvm";
 import { NotFound } from "@/pages/NotFound";
+import { Reports } from "@/pages/Reports";
 import { RiskAudit } from "@/pages/RiskAudit";
 import { SmartOps } from "@/pages/SmartOps";
 import { VelocityFlow } from "@/pages/VelocityFlow";
@@ -28,6 +29,7 @@ const router = createBrowserRouter([
       { path: "ai", element: <AiGovernance /> },
       { path: "smart-ops", element: <SmartOps /> },
       { path: "raid", element: <RiskAudit /> },
+      { path: "reports", element: <Reports /> },
       { path: "data-hub", element: <DataHub /> },
       { path: "*", element: <NotFound /> },
     ],

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,7 +13,7 @@ const tabs = [
   { to: "/ai", label: "AI Governance", num: "07" },
   { to: "/smart-ops", label: "Smart Ops", num: "08" },
   { to: "/raid", label: "Risk & Audit", num: "09" },
-  { to: "/reports", label: "Reports", num: "10", disabled: true },
+  { to: "/reports", label: "Reports", num: "10" },
   { to: "/data-hub", label: "Data Hub", num: "11" },
 ];
 
@@ -48,32 +48,20 @@ export function Layout() {
               key={tab.to}
               to={tab.to}
               end={tab.to === "/"}
-              aria-disabled={tab.disabled ? true : undefined}
               className={({ isActive }) =>
                 cn(
                   "group flex items-center justify-between rounded-md px-3 py-2 text-sm font-medium transition",
-                  tab.disabled
-                    ? "pointer-events-none text-navy/40"
-                    : "text-navy hover:bg-ice-50",
-                  isActive && !tab.disabled && "bg-navy text-white shadow-sm",
+                  "text-navy hover:bg-ice-50",
+                  isActive && "bg-navy text-white shadow-sm",
                 )
               }
             >
               <span>{tab.label}</span>
-              <span
-                className={cn(
-                  "font-mono text-xs",
-                  tab.disabled ? "text-navy/30" : "text-navy/50 group-hover:text-navy",
-                )}
-              >
+              <span className="font-mono text-xs text-navy/50 group-hover:text-navy">
                 {tab.num}
               </span>
             </NavLink>
           ))}
-          <p className="mt-4 px-3 text-[11px] leading-snug text-navy/50">
-            Tabs 02–10 light up across Iterations 2–4. See
-            <span className="font-mono"> docs/ROADMAP.md</span>.
-          </p>
         </nav>
 
         <main className="flex-1 overflow-x-hidden p-6">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -738,6 +738,43 @@ export async function fetchAuditLog(
   return data;
 }
 
+// ---------- Reports & Forecasts ----------
+
+export type Forecast = {
+  kpi_code: string;
+  programme_code: string | null;
+  historical_dates: string[];
+  historical_values: number[];
+  horizon_months: number;
+  horizon_labels: string[];
+  series: { label: string; values: number[] }[];
+};
+
+export async function fetchForecast(
+  kpiCode: string,
+  programmeCode?: string,
+  horizon = 3,
+): Promise<Forecast> {
+  const { data } = await api.get<Forecast>("/api/v1/forecasts", {
+    params: {
+      kpi_code: kpiCode,
+      programme_code: programmeCode,
+      horizon,
+    },
+  });
+  return data;
+}
+
+export function qbrPdfUrl(programId: number): string {
+  return `/api/v1/reports/qbr/${programId}.pdf`;
+}
+
+export function auditPackageUrl(programId?: number): string {
+  return programId !== undefined
+    ? `/api/v1/reports/audit-package.zip?program_id=${programId}`
+    : `/api/v1/reports/audit-package.zip`;
+}
+
 export async function previewCsv(file: File): Promise<{
   filename: string;
   columns: string[];

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -1,0 +1,315 @@
+import { useState } from "react";
+import { FileDown, Home, Package, Sparkles, TrendingUp } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Breadcrumb } from "@/components/Breadcrumb";
+import { Card, CardHeader } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import {
+  auditPackageUrl,
+  fetchForecast,
+  qbrPdfUrl,
+  type Forecast,
+} from "@/lib/api";
+import { useProgrammes } from "@/hooks/usePortfolio";
+
+const FORECAST_KPIS = [
+  { code: "CPI", label: "Cost Performance Index" },
+  { code: "SPI", label: "Schedule Performance Index" },
+  { code: "MARGIN", label: "Blended Margin" },
+  { code: "AI_TRUST", label: "AI Trust Score" },
+];
+
+export function Reports() {
+  const programmes = useProgrammes();
+  const [forecastKpi, setForecastKpi] = useState("CPI");
+  const [forecastProgramme, setForecastProgramme] = useState<string | "">(
+    "",
+  );
+
+  const forecast = useQuery({
+    queryKey: ["forecast", forecastKpi, forecastProgramme || "all"],
+    queryFn: () => fetchForecast(forecastKpi, forecastProgramme || undefined, 3),
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Breadcrumb
+        items={[
+          { label: "Portfolio", to: "/", icon: <Home className="size-3" aria-hidden="true" /> },
+          { label: "Reports & Exports" },
+        ]}
+      />
+
+      <div>
+        <h1 className="text-2xl font-semibold text-navy">Reports & Exports</h1>
+        <p className="mt-1 text-sm text-navy/70">
+          One-click PDF briefs, audit evidence packages, and a forward-looking
+          view that runs the three forecast primitives from
+          <code> app/services/forecast.py</code> against any seeded KPI.
+        </p>
+      </div>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader
+            title="QBR brief per programme"
+            subtitle="One-page PDF (ReportLab): snapshot + commentary + top risks + open actions"
+            action={<FileDown className="size-4 text-amber-500" aria-hidden="true" />}
+          />
+          <ul className="flex flex-col gap-2 text-sm">
+            {(programmes.data ?? []).map((p) => (
+              <li
+                key={p.id}
+                className="flex items-center justify-between gap-3 rounded border border-ice-100 bg-white px-3 py-2"
+              >
+                <div>
+                  <p className="font-medium">{p.name}</p>
+                  <p className="text-xs text-navy/60">
+                    {p.code} · {p.client ?? "—"}
+                  </p>
+                </div>
+                <a
+                  href={qbrPdfUrl(p.id)}
+                  className="btn-primary text-xs"
+                  download={`qbr-${p.code.toLowerCase()}.pdf`}
+                >
+                  <FileDown className="size-3" /> Download QBR
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Card>
+
+        <Card>
+          <CardHeader
+            title="Audit evidence package"
+            subtitle="ZIP of risks, CRs, SLA incidents, KPI snapshots, customer satisfaction and audit_log — filtered if you pick a programme"
+            action={<Package className="size-4 text-navy/60" aria-hidden="true" />}
+          />
+          <div className="flex flex-col gap-3">
+            <a
+              href={auditPackageUrl()}
+              className="btn-primary w-max text-xs"
+              download="audit-portfolio.zip"
+            >
+              <Package className="size-3" /> Portfolio-wide audit ZIP
+            </a>
+            <p className="kpi-label">Per programme</p>
+            <ul className="flex flex-col gap-1 text-sm">
+              {(programmes.data ?? []).map((p) => (
+                <li key={p.id}>
+                  <a
+                    href={auditPackageUrl(p.id)}
+                    className="inline-flex items-center gap-2 rounded px-2 py-1 font-mono text-xs text-navy hover:bg-ice-50"
+                    download={`audit-${p.code.toLowerCase()}.zip`}
+                  >
+                    <Package className="size-3" aria-hidden="true" /> {p.code} audit ZIP
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Predictive forecast"
+          subtitle="Linear trend + weighted MA + exponential smoothing, 3-month horizon"
+          action={<TrendingUp className="size-4 text-success-600" aria-hidden="true" />}
+        />
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="kpi-label">KPI</span>
+            <select
+              value={forecastKpi}
+              onChange={(e) => setForecastKpi(e.target.value)}
+              className="rounded border border-ice-100 px-3 py-1 font-mono text-xs text-navy"
+            >
+              {FORECAST_KPIS.map((k) => (
+                <option key={k.code} value={k.code}>
+                  {k.code} — {k.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="kpi-label">Programme</span>
+            <select
+              value={forecastProgramme}
+              onChange={(e) => setForecastProgramme(e.target.value)}
+              className="rounded border border-ice-100 px-3 py-1 font-mono text-xs text-navy"
+            >
+              <option value="">Portfolio (aggregate)</option>
+              {(programmes.data ?? []).map((p) => (
+                <option key={p.id} value={p.code}>
+                  {p.code} — {p.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-4 h-80">
+          {forecast.isLoading ? (
+            <p className="grid h-full place-items-center text-sm text-navy/60">
+              Running forecast…
+            </p>
+          ) : forecast.error ? (
+            <p className="text-sm text-danger-600">
+              {(forecast.error as Error).message}
+            </p>
+          ) : forecast.data && forecast.data.historical_values.length === 0 ? (
+            <p className="grid h-full place-items-center text-sm text-navy/60">
+              No snapshots seeded for this KPI/programme combination.
+            </p>
+          ) : forecast.data ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={buildChartData(forecast.data)}
+                margin={{ top: 8, right: 24, left: 0, bottom: 8 }}
+              >
+                <CartesianGrid stroke="#E4EEF4" strokeDasharray="4 4" />
+                <XAxis
+                  dataKey="label"
+                  stroke="#1B2A4A"
+                  tick={{ fontSize: 12 }}
+                />
+                <YAxis stroke="#1B2A4A" tick={{ fontSize: 12 }} />
+                <Tooltip contentStyle={{ border: "1px solid #D5E8F0" }} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <ReferenceLine
+                  x={buildBoundaryLabel(forecast.data)}
+                  stroke="#F59E0B"
+                  strokeDasharray="3 4"
+                  label={{
+                    value: "Forecast →",
+                    position: "insideTopLeft",
+                    fill: "#F59E0B",
+                    fontSize: 11,
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="historical"
+                  name="Historical"
+                  stroke="#1B2A4A"
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="linear"
+                  name="Linear trend"
+                  stroke="#F59E0B"
+                  strokeWidth={2}
+                  strokeDasharray="4 4"
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="wma"
+                  name="Weighted MA"
+                  stroke="#10B981"
+                  strokeWidth={2}
+                  strokeDasharray="4 4"
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="exp"
+                  name="Exp. smoothing"
+                  stroke="#8B5CF6"
+                  strokeWidth={2}
+                  strokeDasharray="4 4"
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          ) : null}
+        </div>
+        <p className="mt-2 text-xs text-navy/60">
+          <Sparkles className="inline size-3 text-amber-500" aria-hidden="true" />
+          {" "}
+          The three curves diverge after the vertical line — treat each as a
+          different prior on the next 3 months.
+        </p>
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="How to read each export"
+          subtitle="Before you forward to a customer or auditor"
+        />
+        <ul className="flex flex-col gap-2 text-sm text-navy/80">
+          <li>
+            <Badge tone="neutral">QBR PDF</Badge> Single page, portrait A4, safe
+            to print or email. Page title uses the programme's full name; the
+            top table captures the latest CPI/SPI/margin/renewal snapshot.
+          </li>
+          <li>
+            <Badge tone="neutral">Audit ZIP</Badge> Contains a <code>.json</code>
+            file per evidence table plus a <code>README.txt</code> with a
+            timestamp and a reference to <code>docs/SECURITY_GUIDE.md</code>.
+            Payloads are the raw rows — suitable for offline review.
+          </li>
+          <li>
+            <Badge tone="amber">Forecast</Badge> Three parallel models. When
+            they agree, confidence is higher. When linear-trend sprints away
+            from the other two, treat that as a volatility flag.
+          </li>
+        </ul>
+      </Card>
+    </div>
+  );
+}
+
+type ChartRow = {
+  label: string;
+  historical: number | null;
+  linear: number | null;
+  wma: number | null;
+  exp: number | null;
+};
+
+function buildChartData(forecast: Forecast): ChartRow[] {
+  const rows: ChartRow[] = [];
+  forecast.historical_dates.forEach((d, idx) => {
+    rows.push({
+      label: d.slice(0, 7),
+      historical: forecast.historical_values[idx],
+      linear: null,
+      wma: null,
+      exp: null,
+    });
+  });
+  const linear = forecast.series.find((s) => s.label === "Linear trend");
+  const wma = forecast.series.find((s) => s.label === "Weighted moving avg");
+  const exp = forecast.series.find((s) => s.label === "Exponential smoothing");
+  forecast.horizon_labels.forEach((lbl, idx) => {
+    rows.push({
+      label: lbl,
+      historical: null,
+      linear: linear?.values[idx] ?? null,
+      wma: wma?.values[idx] ?? null,
+      exp: exp?.values[idx] ?? null,
+    });
+  });
+  return rows;
+}
+
+function buildBoundaryLabel(forecast: Forecast): string | undefined {
+  if (forecast.historical_dates.length === 0) return undefined;
+  return forecast.historical_dates[forecast.historical_dates.length - 1].slice(0, 7);
+}


### PR DESCRIPTION
## Summary
Lands **Tab 10 Reports & Exports** and the predictive-forecast endpoint that the KPI Studio stub has been pointing to since Iteration 1.

## What's in

**Backend**
- `app/services/reports.py` — ReportLab-based QBR brief (one-page A4 with snapshot table, commentary, top risks, open actions) and an audit-evidence ZIP bundler (JSON dumps of risks / CRs / SLA incidents / KPI snapshots / customer satisfaction / audit_log + dated README).
- `GET /api/v1/reports/qbr/{program_id}.pdf` · `GET /api/v1/reports/audit-package.zip` (optional `program_id` scope).
- `GET /api/v1/forecasts` — thin wrapper around the `linear_trend` / `weighted_moving_average` / `exponential_smoothing` primitives already in `app/services/forecast.py`. Returns 3 parallel series + historical.

**Frontend — Tab 10**
- Per-programme QBR download list.
- Portfolio-wide + per-programme audit ZIP downloads.
- Forecast chart: KPI + programme dropdowns, Recharts LineChart with a `ReferenceLine` marking where historical ends and forecast begins.
- Explainer card describing each export artifact.

**Housekeeping**
- Dropped now-obsolete `disabled` plumbing in `Layout.tsx` (every tab is live).
- `CHANGELOG.md` in Keep-a-Changelog format covering PRs #1–#8 and this in-flight work.

## Smoke (via nginx proxy)
- QBR Phoenix → 200, 3283 B PDF.
- Audit ZIP portfolio → 200, 10383 B.
- Forecast CPI/PHOENIX → 3 series × 3-month horizon vs 12 historical points.

## Still to ship in I-4b
Playwright E2E golden path · axe-core accessibility pass · CycloneDX SBOM · cold-start timing script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)